### PR TITLE
Add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![](res/radiorave_logo.png)
 
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/OpenFusionProject/OpenFusion?svg=true)](https://ci.appveyor.com/project/Raymonf/openfusion)
+[![Discord](https://img.shields.io/badge/chat-on%20discord-7289da.svg?logo=discord)](https://discord.gg/DYavckB)
 
 OpenFusion is a landwalker server for FusionFall. It currently supports versions `beta-20100104` and `beta-20100728` of the original game.
 


### PR DESCRIPTION
This adds a new badge alongside appveyor to join the Discord server.

Preview:
![image](https://user-images.githubusercontent.com/5341136/90847963-552aea80-e331-11ea-8ab6-8e5f1e434e8e.png)
