### PR TITLE
Cleaned up protocol selection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@ project(OpenFusion)
 set(CMAKE_CXX_STANDARD 17)
 
 # OpenFusion supports multiple packet/struct versions
-# 0104 is the default version to build which can be changed
-# For example: cmake -B build -DPACKET_VERSION=0728
-OPTION(PACKET_VERSION "The packet version to build" "0104")
+# 104 is the default version to build which can be changed
+# For example: cmake -B build -DPROTOCOL_VERSION=728
+set(PROTOCOL_VERSION 104 CACHE STRING "The packet version to build")
 
-ADD_DEFINITIONS(-DCNPROTO_OVERRIDE -DCNPROTO_VERSION_${PACKET_VERSION})
+add_compile_definitions(PROTOCOL_VERSION=${PROTOCOL_VERSION})
 
 # Disallow in-source builds
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 CXX=clang++
 # -w suppresses all warnings (the part that's commented out helps me find memory leaks, it ruins performance though!)
-CXXFLAGS=-std=c++17 -O3 #-g3 -fsanitize=address
+CXXFLAGS=-std=c++17 -O3 -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
 LDFLAGS=-lpthread
 # specifies the name of our exectuable
 SERVER=bin/fusion
+
+# assign protocol version
+# this can be overriden by ex. make PROTOCOL_VERSION=728
+PROTOCOL_VERSION?=104
 
 # Windows-specific
 WIN_CXX=x86_64-w64-mingw32-g++
@@ -49,7 +53,7 @@ all: $(SERVER)
 
 windows: $(SERVER)
 
-# Assign Windows-specific values if targeting Windows
+# assign Windows-specific values if targeting Windows
 windows : CXX=$(WIN_CXX)
 windows : CXXFLAGS=$(WIN_CXXFLAGS)
 windows : LDFLAGS=$(WIN_LDFLAGS)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ for:
                 Remove-Item "build" -Recurse
                 Write-Output "Deleted existing build folder"
             }
-            Invoke-Expression "cmake -B build -DPACKET_VERSION=$version"
+            Invoke-Expression "cmake -B build -DPROTOCOL_VERSION=$version"
             if ($LASTEXITCODE -ne "0") {
                 Write-Error "cmake generation failed for version $version" -ErrorAction Stop
             }

--- a/src/CNStructs.hpp
+++ b/src/CNStructs.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
     CNStructs.hpp - defines some basic structs & useful methods for packets used by FusionFall based on the version defined
 */
 
@@ -21,9 +21,9 @@
     #include <time.h>
 #endif
 #include <cstring>
-#include <string> 
-#include <locale> 
-#include <codecvt> 
+#include <string>
+#include <locale>
+#include <codecvt>
 
 // TODO: rewrite U16toU8 & U8toU16 to not use codecvt
 
@@ -31,18 +31,15 @@ std::string U16toU8(char16_t* src);
 int U8toU16(std::string src, char16_t* des); // returns number of char16_t that was written at des
 uint64_t getTime();
 
-// The CNPROTO_OVERRIDE definition is defined by cmake if you use it.
-// If you don't use cmake, feel free to comment this out and change it around.
-// Otherwise, use the PACKET_VERSION option (e.g. -DPACKET_VERSION=0104 in the cmake command) to change it.
-#if !defined(CNPROTO_OVERRIDE)
-    //#define CNPROTO_VERSION_0728
-    #define CNPROTO_VERSION_0104
-#endif
-
-#if defined(CNPROTO_VERSION_0104)
-    #include "structs/0104.hpp"
-#elif defined(CNPROTO_VERSION_0728)
+// The PROTOCOL_VERSION definition is defined by the build system.
+#if !defined(PROTOCOL_VERSION)
+    #error "PROTOCOL_VERSION not defined"
+#elif PROTOCOL_VERSION == 728
     #include "structs/0728.hpp"
+#elif PROTOCOL_VERSION == 104
+    #include "structs/0104.hpp"
+#else
+    #error Invalid PROTOCOL_VERSION
 #endif
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@ int main() {
     }
 #endif
     settings::init();
+    std::cout << "[INFO] Protocol version: " << PROTOCOL_VERSION << std::endl;
     std::cout << "[INFO] Intializing Packet Managers..." << std::endl;
     PlayerManager::init();
     ChatManager::init();


### PR DESCRIPTION
* cmake now works even if protocol option is omitted
* make now supports protocol selection
* removed PACKET_VERSION/CNPROTO_VERSION* redundancy
* ubuntu appveyor script has yet to be written
* cleaned up some trailing spaces