### PR TITLE
Sanity checks + Starting level changes

### DIFF
--- a/src/CNLoginServer.cpp
+++ b/src/CNLoginServer.cpp
@@ -210,11 +210,11 @@ void CNLoginServer::handlePacket(CNSocket* sock, CNPacketData* data) {
             resp.sPC_Style2.iAppearanceFlag = 1;
             resp.sPC_Style2.iTutorialFlag = 1;
             resp.sPC_Style2.iPayzoneFlag = 1;
-            resp.iLevel = 1;
+            resp.iLevel = 36;
             resp.sOn_Item = character->sOn_Item;
 
             loginSessions[sock].characters[UID] = Player();
-            loginSessions[sock].characters[UID].level = 1;
+            loginSessions[sock].characters[UID].level = 36;
             loginSessions[sock].characters[UID].FEKey = sock->getFEKey();
             loginSessions[sock].characters[UID].PCStyle = character->PCStyle;
             loginSessions[sock].characters[UID].PCStyle2.iAppearanceFlag = 1;

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -32,6 +32,9 @@ void ItemManager::itemMoveHandler(CNSocket* sock, CNPacketData* data) {
         return;
     }
     
+    if (itemmove->iToSlotNum > AINVEN_COUNT) 
+        return; // sanity checks
+    
     sItemBase fromItem;
     sItemBase toItem;
 

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -187,7 +187,7 @@ void PlayerManager::enterPlayer(CNSocket* sock, CNPacketData* data) {
     response.iID = rand();
     response.uiSvrTime = getTime();
     response.PCLoadData2CL.iUserLevel = 1;
-    response.PCLoadData2CL.iHP = 1000 * plr.level;
+    response.PCLoadData2CL.iHP = 3625; //TODO: Check player levelupdata and get this right
     response.PCLoadData2CL.iLevel = plr.level;
     response.PCLoadData2CL.iMentor = 1;
     response.PCLoadData2CL.iMentorCount = 4;


### PR DESCRIPTION
- Item movement handler checks to make sure items aren't moved from equipment slot to equipment slot.
- Item give command checks to make sure an out of bounds item is not spawned (Below iType 0 or above iType 8)
- Players now begin at level 36, consequently the item give command does not level you up now.