### PR TITLE
Add .editorconfig to enforce 4 space indent, final newline, and LF EoL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[*.cpp,*.hpp]
+indent_style = space
+indent_size = 4
+
+# Tabs in makefile
+[Makefile]
+indent_style = tab
+
+# Don't enforce anything in contrib
+[/src/contrib/**]
+end_of_line = unset
+insert_final_newline = unset
+indent_style = unset
+indent_style = unset


### PR DESCRIPTION
Should be supported by [most IDEs and text editors](https://editorconfig.org/#download).