### PR TITLE
Temporarily set npcBarkHandler to a stub

### DIFF
--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -144,22 +144,7 @@ void NPCManager::updatePlayerNPCS(CNSocket* sock, PlayerView& view) {
     PlayerManager::players[sock].viewableNPCs = view.viewableNPCs;
 }
 
-void NPCManager::npcBarkHandler(CNSocket* sock, CNPacketData* data) {
-    sP_CL2FE_REQ_BARKER* bark = (sP_CL2FE_REQ_BARKER*)data->buf;
-    PlayerView& plr = PlayerManager::players[sock];
-
-    INITSTRUCT(sP_FE2CL_REP_BARKER, resp);
-    resp.iMissionStringID = bark->iMissionTaskID;
-    resp.iNPC_ID = bark->iNPC_ID;
-
-    // Send bark to other players.
-    for (CNSocket* otherSock : plr.viewable) {
-        otherSock->sendPacket((void*)&resp, P_FE2CL_REP_BARKER, sizeof(sP_FE2CL_REP_BARKER));
-    }
-
-    // Then ourself.
-    sock->sendPacket((void*)&resp, P_FE2CL_REP_BARKER, sizeof(sP_FE2CL_REP_BARKER));
-}
+void NPCManager::npcBarkHandler(CNSocket* sock, CNPacketData* data) {} // stubbed for now
 
 void NPCManager::npcSummonHandler(CNSocket* sock, CNPacketData* data) {
     if (data->size != sizeof(sP_CL2FE_REQ_NPC_SUMMON))


### PR DESCRIPTION
The current implementation caused bugs where certain NPCs said mission description text or other dialogue that wasn't meant for them:
![OpenFusionClient_2020-08-30_16-36-17](https://user-images.githubusercontent.com/5341136/92328699-3febd680-f028-11ea-96d0-e67dacbf3f56.png)

In order to fix this, it would require further research into how the barkers were handled in the original game or Retro. So to fix the bug temporarily, I replaced the handler with a stub that can be expanded upon later down the line. This should also reduce server log spam.