### PR TITLE
MinGW optimization fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC=clang
 CXX=clang++
 # -w suppresses all warnings (the part that's commented out helps me find memory leaks, it ruins performance though!)
 CFLAGS=-O3 #-g3 -fsanitize=address
-CXXFLAGS=-Wall -std=c++17 -O2 -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
+CXXFLAGS=-Wall -Wno-unknown-pragmas -std=c++17 -O2 -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
 LDFLAGS=-lpthread -ldl #-g3 -fsanitize=address
 # specifies the name of our exectuable
 SERVER=bin/fusion
@@ -15,7 +15,7 @@ PROTOCOL_VERSION?=104
 WIN_CC=x86_64-w64-mingw32-gcc
 WIN_CXX=x86_64-w64-mingw32-g++
 WIN_CFLAGS=-O3 #-g3 -fsanitize=address
-WIN_CXXFLAGS=-Wall -std=c++17 -O3 -fno-tree-dce -fno-inline-small-functions -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
+WIN_CXXFLAGS=-Wall -Wno-unknown-pragmas -std=c++17 -O3 -fno-tree-dce -fno-inline-small-functions -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
 WIN_LDFLAGS=-static -lws2_32 -lwsock32 #-g3 -fsanitize=address
 WIN_SERVER=bin/winfusion.exe
 

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ PROTOCOL_VERSION?=104
 # Windows-specific
 WIN_CC=x86_64-w64-mingw32-gcc
 WIN_CXX=x86_64-w64-mingw32-g++
-WIN_CFLAGS=-O0 #-g3 -fsanitize=address
-WIN_CXXFLAGS=-Wall -std=c++17 -O0 -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
+WIN_CFLAGS=-O3 #-g3 -fsanitize=address
+WIN_CXXFLAGS=-Wall -std=c++17 -O3 -fno-tree-dce -fno-inline-small-functions -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
 WIN_LDFLAGS=-static -lws2_32 -lwsock32 #-g3 -fsanitize=address
 WIN_SERVER=bin/winfusion.exe
 


### PR DESCRIPTION
Disabling 2 specific optimizations allows us to bump the optimization level back to `O3` for Windows MinGW.