### PR TITLE
Warnings and compile errors for MSYS2 MinGW64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ PROTOCOL_VERSION?=104
 WIN_CC=x86_64-w64-mingw32-gcc
 WIN_CXX=x86_64-w64-mingw32-g++
 WIN_CFLAGS=-O3 #-g3 -fsanitize=address
-WIN_CXXFLAGS=-Wall -Wno-unknown-pragmas -std=c++17 -O3 -fno-tree-dce -fno-tree-fre -fno-tree-vrp -fno-ipa-sra -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
+WIN_CXX_VANILLA_MINGW_OPT_DISABLES=-fno-tree-dce -fno-inline-small-functions
+WIN_CXX_OPT_DISABLES=-fno-tree-dce -fno-tree-fre -fno-tree-vrp -fno-ipa-sra
+WIN_CXXFLAGS=-Wall -Wno-unknown-pragmas -std=c++17 -O3 $(WIN_CXX_OPT_DISABLES) -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
 WIN_LDFLAGS=-static -lws2_32 -lwsock32 #-g3 -fsanitize=address
 WIN_SERVER=bin/winfusion.exe
 
@@ -98,6 +100,10 @@ windows : CFLAGS=$(WIN_CFLAGS)
 windows : CXXFLAGS=$(WIN_CXXFLAGS)
 windows : LDFLAGS=$(WIN_LDFLAGS)
 windows : SERVER=$(WIN_SERVER)
+windows :
+ifneq ($(shell $(WIN_CXX) --version | head -1 | egrep -o [0-9]+ | tail -3 | head -1), 10)
+WIN_CXX_OPT_DISABLES=$(WIN_CXX_VANILLA_MINGW_OPT_DISABLES)
+endif
 
 .SUFFIX: .o .c .cpp .h .hpp
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PROTOCOL_VERSION?=104
 WIN_CC=x86_64-w64-mingw32-gcc
 WIN_CXX=x86_64-w64-mingw32-g++
 WIN_CFLAGS=-O3 #-g3 -fsanitize=address
-WIN_CXXFLAGS=-Wall -Wno-unknown-pragmas -std=c++17 -O3 -fno-tree-dce -fno-inline-small-functions -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
+WIN_CXXFLAGS=-Wall -Wno-unknown-pragmas -std=c++17 -O3 -fno-tree-dce -fno-tree-fre -fno-tree-vrp -fno-ipa-sra -DPROTOCOL_VERSION=$(PROTOCOL_VERSION) #-g3 -fsanitize=address
 WIN_LDFLAGS=-static -lws2_32 -lwsock32 #-g3 -fsanitize=address
 WIN_SERVER=bin/winfusion.exe
 

--- a/src/CNStructs.cpp
+++ b/src/CNStructs.cpp
@@ -5,16 +5,16 @@
 
 std::string U16toU8(char16_t* src) {
     try {
-        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> convert; 
-        return convert.to_bytes(src);   
-    } catch(std::exception e) {
+        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> convert;
+        return convert.to_bytes(src);
+    } catch(const std::exception& e) {
         return "";
     }
 }
 
 // returns number of char16_t that was written at des
 size_t U8toU16(std::string src, char16_t* des) {
-    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> convert; 
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> convert;
     std::u16string tmp = convert.from_bytes(src);
 
     // copy utf16 string to buffer


### PR DESCRIPTION
~~**Warning**: Do not merge unless we decide MSYS2 MinGW64 should be the standard MinGW64 for this project.~~ Can now be merged since we don't have to choose yet.

Also another consideration to make:
`-fno-ipa-sra` removes tons of `-Wuninitialized` and `-Wmaybe-uninitialized` types of warnings you get while compiling `Database.cpp`. Should we use `-Wno-uninitialized` and `-Wno-maybe-uninitialized` to disable the warnings and keep the optimization, or should we play it safe and disable the optimization?