### PR TITLE
Add .gitattributes file, exclude src/contrib from linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/contrib/* linguist-vendored


### PR DESCRIPTION
Currently, the repo is detected as 82% C and 18% C++, this is due to the src/contrib folder containing some larger C libraries. 
![image](https://user-images.githubusercontent.com/5341136/92531771-90b02a80-f1f4-11ea-93be-648a9cc9a572.png)
By adding a .gitattributes file to exclude these from the count, the problem should be solved.

Edit: According to the [README of Linguist](https://github.com/github/linguist), these changes may take a while to apply once merged:
![image](https://user-images.githubusercontent.com/5341136/92532165-52ffd180-f1f5-11ea-92db-8ee92b635791.png)
