### PR TITLE
Levelling up added to /nano

### DIFF
--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -141,6 +141,21 @@ void NanoManager::addNano(CNSocket* sock, int16_t nanoId, int16_t slot) {
 
     // Update player
     plr->Nanos[nanoId] = resp.Nano;
+    
+    // After a nano gets added, setting the level seems to be important so we are doing that
+    if (nanoId < plr->level)
+        nanoId = plr->level;
+    // Even if player level is unchanged, this packet still needs to be sent as using /nano always sets the player to 0
+    INITSTRUCT(sP_FE2CL_REP_PC_CHANGE_LEVEL, resp2);
+
+    resp2.iPC_ID = plr->iID;
+    resp2.iPC_Level = nanoId;
+
+    sock->sendPacket((void*)&resp2, P_FE2CL_REP_PC_CHANGE_LEVEL, sizeof(sP_FE2CL_REP_PC_CHANGE_LEVEL));
+    for (CNSocket* s : PlayerManager::players[sock].viewable)
+        s->sendPacket((void*)&resp2, P_FE2CL_REP_PC_CHANGE_LEVEL, sizeof(sP_FE2CL_REP_PC_CHANGE_LEVEL));
+
+    plr->level = nanoId;
 }
 
 void NanoManager::summonNano(CNSocket *sock, int slot) {


### PR DESCRIPTION
- Using /nano levels up Player, a player cannot level down.