### PR TITLE
Move from isGM to Account Levels

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -32,8 +32,14 @@ npcdata=tdata/NPCs.json
 xdtdata=tdata/xdt.json
 # mob json
 mobdata=tdata/mobs.json
-# is everyone a GM?
-gm=true
+
+# account permission level that will be set upon character creation
+# 1 = default, will allow *all* commands
+# 30 = allow some more "abusable" commands such as /summon
+# 50 = only allow cheat commands, like /itemN and /speed
+# 99 = standard user account, no cheats allowed
+# any number higher than 50 will disable commands
+accountlevel=1
 
 # spawn coordinates (Z is height)
 # the supplied defaults are at Sector V (future)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -52,7 +52,7 @@ auto db = make_storage("database.db",
         make_column("Height", &Database::DbPlayer::Height),
         make_column("NameCheck", &Database::DbPlayer::NameCheck),
         make_column("SkinColor", &Database::DbPlayer::SkinColor),
-        make_column("isGM", &Database::DbPlayer::isGM),
+        make_column("AccountLevel", &Database::DbPlayer::AccountLevel),
         make_column("FusionMatter", &Database::DbPlayer::FusionMatter),
         make_column("Taros", &Database::DbPlayer::Taros),
         make_column("Quests", &Database::DbPlayer::QuestFlag),
@@ -202,7 +202,7 @@ int Database::createCharacter(sP_CL2LS_REQ_SAVE_CHAR_NAME* save, int AccountID)
     create.HairStyle = 1;
     create.Height = 0;
     create.SkinColor = 1;
-    create.isGM = settings::GM;
+    create.AccountLevel = settings::ACCLEVEL;
     create.x_coordinates = settings::SPAWN_X;
     create.y_coordinates = settings::SPAWN_Y;
     create.z_coordinates = settings::SPAWN_Z;
@@ -347,7 +347,7 @@ Database::DbPlayer Database::playerToDb(Player *player)
     result.HairStyle = player->PCStyle.iHairStyle;
     result.Height = player->PCStyle.iHeight;
     result.HP = player->HP;
-    result.isGM = player->IsGM;
+    result.AccountLevel = player->accountLevel;
     result.LastName = U16toU8(player->PCStyle.szLastName);
     result.Level = player->level;
     result.NameCheck = player->PCStyle.iNameCheck;
@@ -402,7 +402,7 @@ Player Database::DbToPlayer(DbPlayer player) {
     result.PCStyle.iHairStyle = player.HairStyle;
     result.PCStyle.iHeight = player.Height;
     result.HP = player.HP;
-    result.IsGM = player.isGM;
+    result.accountLevel = player.AccountLevel;
     U8toU16(player.LastName, result.PCStyle.szLastName);
     result.level = player.Level;
     result.PCStyle.iNameCheck = player.NameCheck;

--- a/src/Database.hpp
+++ b/src/Database.hpp
@@ -58,7 +58,7 @@ namespace Database {
         short int PayZoneFlag;
         short int SkinColor;
         bool TutorialFlag;
-        bool isGM;
+        int AccountLevel;
         int FusionMatter;
         int Taros;
         int x_coordinates;

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -158,11 +158,10 @@ void ItemManager::itemGMGiveHandler(CNSocket* sock, CNPacketData* data) {
     sP_CL2FE_REQ_PC_GIVE_ITEM* itemreq = (sP_CL2FE_REQ_PC_GIVE_ITEM*)data->buf;
     PlayerView& plr = PlayerManager::players[sock];
 
-    // Commented and disabled for future use
-    //if (!plr.plr->IsGM) {
+    if (plr.plr->accountLevel > 50) {
     	// TODO: send fail packet
-    //    return;
-    //}
+        return;
+    }
 
     if (itemreq->eIL == 2) {
         // Quest item, not a real item, handle this later, stubbed for now

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -408,7 +408,7 @@ void NPCManager::npcUnsummonHandler(CNSocket* sock, CNPacketData* data) {
     if (data->size != sizeof(sP_CL2FE_REQ_NPC_UNSUMMON))
         return; // malformed packet
 
-    if (!PlayerManager::getPlayer(sock)->IsGM)
+    if (PlayerManager::getPlayer(sock)->accountLevel > 30)
         return;
     
     sP_CL2FE_REQ_NPC_UNSUMMON* req = (sP_CL2FE_REQ_NPC_UNSUMMON*)data->buf;
@@ -424,7 +424,7 @@ void NPCManager::npcSummonHandler(CNSocket* sock, CNPacketData* data) {
     Player* plr = PlayerManager::getPlayer(sock);
 
     // permission & sanity check
-    if (!plr->IsGM || req->iNPCType >= 3314)
+    if (plr->accountLevel > 30 || req->iNPCType >= 3314)
         return;
 
     resp.NPCAppearanceData.iNPC_ID = NPCs.size()+1;

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -12,6 +12,7 @@
 
 struct Player {
     int accountId;
+    int accountLevel; // permission level (see CN_ACCOUNT_LEVEL enums)
     int64_t SerialKey;
     int32_t iID;
     uint64_t FEKey;
@@ -42,7 +43,6 @@ struct Player {
     int32_t moneyInTrade;
     bool isTrading;
     bool isTradeConfirm;
-    bool IsGM;
 
     int64_t aQuestFlag[16];
     int tasks[ACTIVE_MISSION_COUNT];

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -202,7 +202,7 @@ void PlayerManager::enterPlayer(CNSocket* sock, CNPacketData* data) {
 
     response.iID = plr.iID;
     response.uiSvrTime = getTime();
-    response.PCLoadData2CL.iUserLevel = plr.level;
+    response.PCLoadData2CL.iUserLevel = plr.accountLevel;
     response.PCLoadData2CL.iHP = plr.HP;
     response.PCLoadData2CL.iLevel = plr.level;
     response.PCLoadData2CL.iCandy = plr.money;

--- a/src/TransportManager.cpp
+++ b/src/TransportManager.cpp
@@ -40,7 +40,7 @@ void TransportManager::transportRegisterLocationHandler(CNSocket* sock, CNPacket
         }
 
         // update registration bitfield using bitmask
-        uint32_t newScamperFlag = plr->iWarpLocationFlag | (plr->IsGM ? UINT32_MAX : (1UL << (transport->iLocationID - 1)));
+        uint32_t newScamperFlag = plr->iWarpLocationFlag | (plr->accountLevel <= 40 ? UINT32_MAX : (1UL << (transport->iLocationID - 1)));
         if (newScamperFlag != plr->iWarpLocationFlag) {
             plr->iWarpLocationFlag = newScamperFlag;
             newReg = true;
@@ -61,7 +61,7 @@ void TransportManager::transportRegisterLocationHandler(CNSocket* sock, CNPacket
         /*
          * assuming the two bitfields are just stuck together to make a longer one, do a similar operation
          */
-        if (plr->IsGM) {
+        if (plr->accountLevel <= 40) {
             plr->aSkywayLocationFlag[0] = UINT64_MAX;
             plr->aSkywayLocationFlag[1] = UINT64_MAX;
             newReg = true;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -23,7 +23,7 @@ std::string settings::NPCJSON = "tdata/NPCs.json";
 std::string settings::XDTJSON = "tdata/xdt.json";
 std::string settings::MOBJSON = "tdata/mobs.json";
 std::string settings::MOTDSTRING = "Welcome to OpenFusion!";
-bool settings::GM = true;
+int settings::ACCLEVEL = 1;
 
 void settings::init() {
     INIReader reader("config.ini");
@@ -53,5 +53,5 @@ void settings::init() {
     XDTJSON = reader.Get("shard", "xdtdata", XDTJSON);
     MOBJSON = reader.Get("shard", "mobdata", MOBJSON);
     MOTDSTRING = reader.Get("shard", "motd", MOTDSTRING);
-    GM = reader.GetBoolean("shard", "gm", GM);
+    ACCLEVEL = reader.GetBoolean("shard", "accountlevel", ACCLEVEL);
 }

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -17,7 +17,7 @@ namespace settings {
     extern std::string NPCJSON;
     extern std::string XDTJSON;
     extern std::string MOBJSON;
-    extern bool GM;
+    extern int ACCLEVEL;
 
     void init();
 }


### PR DESCRIPTION
This PR removes the isGM bool and replaces it with the Account Level system built into the client.

Despite the name, accountLevel is actually per character. [It ranges from 1, the highest permission level, to 99 being a regular user](https://github.com/OpenFusionProject/OpenFusion/blob/12fbdc962119e074e6330c00c6b1ae87a1e65f47/src/Defines.hpp#L263). This value is set on character creation, and is decided by a config.ini setting. While not a perfect system, it should allow much more granularity once we add more commands.