### PR TITLE
Fixed Time and implemented vehicles expiring

### DIFF
--- a/src/CNStructs.hpp
+++ b/src/CNStructs.hpp
@@ -33,6 +33,7 @@
 std::string U16toU8(char16_t* src);
 size_t U8toU16(std::string src, char16_t* des); // returns number of char16_t that was written at des
 time_t getTime();
+time_t getTimestamp();
 
 // The PROTOCOL_VERSION definition is defined by the build system.
 #if !defined(PROTOCOL_VERSION)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -611,7 +611,7 @@ void Database::getInventory(Player* player) {
 }
 
 void Database::removeExpiredVehicles(Player* player) {
-    uint64_t currentTime = getTimestamp();
+    int32_t currentTime = getTimestamp()/1000;
     //remove from bank immediately
     for (int i = 0; i < ABANK_COUNT; i++) {
         if (player->Bank[i].iType == 10 && player->Bank[i].iTimeLimit < currentTime)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -611,7 +611,7 @@ void Database::getInventory(Player* player) {
 }
 
 void Database::removeExpiredVehicles(Player* player) {
-    int32_t currentTime = getTimestamp()/1000;
+    int32_t currentTime = getTimestamp();
     //remove from bank immediately
     for (int i = 0; i < ABANK_COUNT; i++) {
         if (player->Bank[i].iType == 10 && player->Bank[i].iTimeLimit < currentTime)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -612,22 +612,22 @@ void Database::getInventory(Player* player) {
 
 void Database::removeExpiredVehicles(Player* player) {
     int32_t currentTime = getTimestamp();
-    //remove from bank immediately
+    // remove from bank immediately
     for (int i = 0; i < ABANK_COUNT; i++) {
         if (player->Bank[i].iType == 10 && player->Bank[i].iTimeLimit < currentTime)
             player->Bank[i] = {};
     }
-    //for the rest, we want to leave only 1 expired vehicle on player to delete it with the client packet
+    // for the rest, we want to leave only 1 expired vehicle on player to delete it with the client packet
     std::vector<sItemBase*> toRemove;
 
-    //equiped vehicle
+    // equiped vehicle
     if (player->Equip[8].iOpt > 0 && player->Equip[8].iTimeLimit < currentTime)
     {
         toRemove.push_back(&player->Equip[8]);
         player->toRemoveVehicle.eIL = 0;
         player->toRemoveVehicle.iSlotNum = 8;
     }
-    //inventory
+    // inventory
     for (int i = 0; i < AINVEN_COUNT; i++) {
         if (player->Inven[i].iType == 10 && player->Inven[i].iTimeLimit < currentTime) {
             toRemove.push_back(&player->Inven[i]);
@@ -636,7 +636,7 @@ void Database::removeExpiredVehicles(Player* player) {
         }
     }
 
-    //delete all but one vehicles, leave last one for ceremonial deletion
+    // delete all but one vehicles, leave last one for ceremonial deletion
     for (int i = 0; i < (int)toRemove.size()-1; i++) {
         memset(toRemove[i], 0, sizeof(sItemBase));
     }

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -637,8 +637,8 @@ void Database::removeExpiredVehicles(Player* player) {
     }
 
     //delete all but one vehicles, leave last one for ceremonial deletion
-    for (int i = 1; i < toRemove.size(); i++) {
-        memset(toRemove[i-1], 0, sizeof(sItemBase));
+    for (int i = 0; i < (int)toRemove.size()-1; i++) {
+        memset(toRemove[i], 0, sizeof(sItemBase));
     }
 }
 

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -128,7 +128,7 @@ int Database::addAccount(std::string login, std::string password)
     account.Login = login;
     account.Password = password;
     account.Selected = 1;
-    account.Created = getTime();
+    account.Created = getTimestamp();
     return db.insert(account);
 }
 
@@ -137,7 +137,7 @@ void Database::updateSelected(int accountId, int slot)
     Account acc = db.get<Account>(accountId);
     acc.Selected = slot;
     //timestamp
-    acc.LastLogin = getTime();
+    acc.LastLogin = getTimestamp();
     db.update(acc);
 }
 
@@ -172,7 +172,7 @@ int Database::createCharacter(sP_CL2LS_REQ_SAVE_CHAR_NAME* save, int AccountID)
     DbPlayer create = {};
     
     //set timestamp
-    create.Created = getTime();
+    create.Created = getTimestamp();
     // save packet data
     create.FirstName = U16toU8(save->szFirstName);
     create.LastName = U16toU8(save->szLastName);
@@ -380,7 +380,7 @@ Database::DbPlayer Database::playerToDb(Player *player)
         appendBlob(&result.QuestFlag, flag);
     }
     //timestamp
-    result.LastLogin = getTime();
+    result.LastLogin = getTimestamp();
     result.Created = getDbPlayerById(player->iID).Created;
 
     return result;
@@ -611,7 +611,7 @@ void Database::getInventory(Player* player) {
 }
 
 void Database::removeExpiredVehicles(Player* player) {
-    uint64_t currentTime = getTime();
+    uint64_t currentTime = getTimestamp();
     //remove from bank immediately
     for (int i = 0; i < ABANK_COUNT; i++) {
         if (player->Bank[i].iType == 10 && player->Bank[i].iTimeLimit < currentTime)

--- a/src/Database.hpp
+++ b/src/Database.hpp
@@ -126,6 +126,7 @@ namespace Database {
     void updateQuests(Player* player);
 
     void getInventory(Player* player);
+    void removeExpiredVehicles(Player* player);
     void getNanos(Player* player);
     void getQuests(Player* player);
 

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -793,9 +793,12 @@ void ItemManager::checkItemExpire(CNSocket* sock, Player* player) {
     itemData->iSlotNum = player->toRemoveVehicle.iSlotNum;
     sock->sendPacket((void*)&respbuf, P_FE2CL_PC_DELETE_TIME_LIMIT_ITEM, resplen);
     
-    //delete serverside
+    // delete serverside
     if (player->toRemoveVehicle.eIL == 0)
         memset(&player->Equip[8], 0, sizeof(sItemBase));
     else
         memset(&player->Inven[player->toRemoveVehicle.iSlotNum], 0, sizeof(sItemBase));
+
+    player->toRemoveVehicle.eIL = 0;
+    player->toRemoveVehicle.iSlotNum = 0;
 }

--- a/src/ItemManager.hpp
+++ b/src/ItemManager.hpp
@@ -47,4 +47,5 @@ namespace ItemManager {
 
     int findFreeSlot(Player *plr);
     Item* getItemData(int32_t id, int32_t type);
+    void checkItemExpire(CNSocket* sock, Player* player);
 }

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -328,7 +328,7 @@ void MissionManager::mobKilled(CNSocket *sock, int mobid) {
             if (task["m_iCSUNumToKill"][j] != 0)
             {
                 missionmob = true;
-                //sanity check
+                // sanity check
                 if (plr->RemainingNPCCount[i][j] == 0) {
                     std::cout << "[WARN] RemainingNPCCount tries to go below 0?!" << std::endl;
                 }

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -328,7 +328,13 @@ void MissionManager::mobKilled(CNSocket *sock, int mobid) {
             if (task["m_iCSUNumToKill"][j] != 0)
             {
                 missionmob = true;
-                plr->RemainingNPCCount[i][j]--;
+                //sanity check
+                if (plr->RemainingNPCCount[i][j] == 0) {
+                    std::cout << "[WARN] RemainingNPCCount tries to go below 0?!" << std::endl;
+                }
+                else {
+                    plr->RemainingNPCCount[i][j]--;
+                }
             }
             // drop quest item
             if (task["m_iCSUItemNumNeeded"][j] != 0 && !isQuestItemFull(sock, task["m_iCSUItemID"][j], task["m_iCSUItemNumNeeded"][j]) ) {

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -115,6 +115,11 @@ void NPCManager::npcVendorBuy(CNSocket* sock, CNPacketData* data) {
         sock->sendPacket((void*)&failResp, P_FE2CL_REP_PC_VENDOR_ITEM_BUY_FAIL, sizeof(sP_FE2CL_REP_PC_VENDOR_ITEM_BUY_FAIL));
         return;
     }
+    // if vehicle
+    if (req->Item.iType == 10)
+        // set time limit: current time + 7days
+        req->Item.iTimeLimit = getTime() + 604800;
+
 
     if (slot != req->iInvenSlotNum) {
         // possible item stacking?

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -118,8 +118,7 @@ void NPCManager::npcVendorBuy(CNSocket* sock, CNPacketData* data) {
     // if vehicle
     if (req->Item.iType == 10)
         // set time limit: current time + 7days
-        req->Item.iTimeLimit = getTimestamp() + 604800;
-
+        req->Item.iTimeLimit = getTimestamp()/1000 + 604800;
 
     if (slot != req->iInvenSlotNum) {
         // possible item stacking?

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -118,7 +118,7 @@ void NPCManager::npcVendorBuy(CNSocket* sock, CNPacketData* data) {
     // if vehicle
     if (req->Item.iType == 10)
         // set time limit: current time + 7days
-        req->Item.iTimeLimit = getTime() + 604800;
+        req->Item.iTimeLimit = getTimestamp() + 604800;
 
 
     if (slot != req->iInvenSlotNum) {

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -118,7 +118,7 @@ void NPCManager::npcVendorBuy(CNSocket* sock, CNPacketData* data) {
     // if vehicle
     if (req->Item.iType == 10)
         // set time limit: current time + 7days
-        req->Item.iTimeLimit = getTimestamp()/1000 + 604800;
+        req->Item.iTimeLimit = getTimestamp() + 604800;
 
     if (slot != req->iInvenSlotNum) {
         // possible item stacking?

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -49,4 +49,6 @@ struct Player {
     int RemainingNPCCount[ACTIVE_MISSION_COUNT][3];
     sItemBase QInven[AQINVEN_COUNT];
     int32_t CurrentMissionID;
+
+    sTimeLimitItemDeleteInfo2CL toRemoveVehicle;
 };

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -691,7 +691,7 @@ void PlayerManager::revivePlayer(CNSocket* sock, CNPacketData* data) {
 void PlayerManager::enterPlayerVehicle(CNSocket* sock, CNPacketData* data) {
     PlayerView& plr = PlayerManager::players[sock];
 
-    if (plr.plr->Equip[8].iID > 0) {
+    if (plr.plr->Equip[8].iID > 0 && plr.plr->Equip[8].iTimeLimit>(getTimestamp()/1000)) {
         INITSTRUCT(sP_FE2CL_PC_VEHICLE_ON_SUCC, response);
         sock->sendPacket((void*)&response, P_FE2CL_PC_VEHICLE_ON_SUCC, sizeof(sP_FE2CL_PC_VEHICLE_ON_SUCC));
 
@@ -709,6 +709,14 @@ void PlayerManager::enterPlayerVehicle(CNSocket* sock, CNPacketData* data) {
     } else {
         INITSTRUCT(sP_FE2CL_PC_VEHICLE_ON_FAIL, response);
         sock->sendPacket((void*)&response, P_FE2CL_PC_VEHICLE_ON_FAIL, sizeof(sP_FE2CL_PC_VEHICLE_ON_FAIL));
+
+        //check if vehicle didn't expire
+        if (plr.plr->Equip[8].iTimeLimit < (getTimestamp() / 1000))
+        {
+            plr.plr->toRemoveVehicle.eIL = 0;
+            plr.plr->toRemoveVehicle.iSlotNum = 8;
+            ItemManager::checkItemExpire(sock, plr.plr);
+        }
     }
 }
 

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -691,7 +691,7 @@ void PlayerManager::revivePlayer(CNSocket* sock, CNPacketData* data) {
 void PlayerManager::enterPlayerVehicle(CNSocket* sock, CNPacketData* data) {
     PlayerView& plr = PlayerManager::players[sock];
 
-    if (plr.plr->Equip[8].iID > 0 && plr.plr->Equip[8].iTimeLimit>(getTimestamp()/1000)) {
+    if (plr.plr->Equip[8].iID > 0 && plr.plr->Equip[8].iTimeLimit>getTimestamp()) {
         INITSTRUCT(sP_FE2CL_PC_VEHICLE_ON_SUCC, response);
         sock->sendPacket((void*)&response, P_FE2CL_PC_VEHICLE_ON_SUCC, sizeof(sP_FE2CL_PC_VEHICLE_ON_SUCC));
 
@@ -711,7 +711,7 @@ void PlayerManager::enterPlayerVehicle(CNSocket* sock, CNPacketData* data) {
         sock->sendPacket((void*)&response, P_FE2CL_PC_VEHICLE_ON_FAIL, sizeof(sP_FE2CL_PC_VEHICLE_ON_FAIL));
 
         //check if vehicle didn't expire
-        if (plr.plr->Equip[8].iTimeLimit < (getTimestamp() / 1000))
+        if (plr.plr->Equip[8].iTimeLimit < getTimestamp())
         {
             plr.plr->toRemoveVehicle.eIL = 0;
             plr.plr->toRemoveVehicle.iSlotNum = 8;

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -4,6 +4,7 @@
 #include "CNShardServer.hpp"
 #include "CNShared.hpp"
 #include "MissionManager.hpp"
+#include "ItemManager.hpp"
 
 #include "settings.hpp"
 
@@ -283,6 +284,8 @@ void PlayerManager::enterPlayer(CNSocket* sock, CNPacketData* data) {
     sock->sendPacket((void*)&motd, P_FE2CL_PC_MOTD_LOGIN, sizeof(sP_FE2CL_PC_MOTD_LOGIN));
 
     addPlayer(sock, plr);
+    //check if there is an expiring vehicle
+    ItemManager::checkItemExpire(sock, getPlayer(sock));
 }
 
 void PlayerManager::sendToViewable(CNSocket* sock, void* buf, uint32_t type, size_t size) {

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -326,7 +326,7 @@ void PlayerManager::movePlayer(CNSocket* sock, CNPacketData* data) {
 
     sP_CL2FE_REQ_PC_MOVE* moveData = (sP_CL2FE_REQ_PC_MOVE*)data->buf;
     updatePlayerPosition(sock, moveData->iX, moveData->iY, moveData->iZ, moveData->iAngle);
-
+    
     players[sock].plr->angle = moveData->iAngle;
     uint64_t tm = getTime();
 
@@ -710,7 +710,7 @@ void PlayerManager::enterPlayerVehicle(CNSocket* sock, CNPacketData* data) {
         INITSTRUCT(sP_FE2CL_PC_VEHICLE_ON_FAIL, response);
         sock->sendPacket((void*)&response, P_FE2CL_PC_VEHICLE_ON_FAIL, sizeof(sP_FE2CL_PC_VEHICLE_ON_FAIL));
 
-        //check if vehicle didn't expire
+        // check if vehicle didn't expire
         if (plr.plr->Equip[8].iTimeLimit < getTimestamp())
         {
             plr.plr->toRemoveVehicle.eIL = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,3 +149,11 @@ time_t getTime() {
 
     return (time_t)value.count();
 }
+
+time_t getTimestamp() {
+    using namespace std::chrono;
+
+    milliseconds value = duration_cast<milliseconds>((time_point_cast<milliseconds>(system_clock::now())).time_since_epoch());
+
+    return (time_t)value.count();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,7 +150,7 @@ time_t getTime() {
     return (time_t)value.count();
 }
 
-//returns system time in seconds
+// returns system time in seconds
 time_t getTimestamp() {
     using namespace std::chrono;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,10 +150,11 @@ time_t getTime() {
     return (time_t)value.count();
 }
 
+//returns system time in seconds
 time_t getTimestamp() {
     using namespace std::chrono;
 
-    milliseconds value = duration_cast<milliseconds>((time_point_cast<milliseconds>(system_clock::now())).time_since_epoch());
+    seconds value = duration_cast<seconds>((time_point_cast<seconds>(system_clock::now())).time_since_epoch());
 
     return (time_t)value.count();
 }


### PR DESCRIPTION
- Timestamps now use system clock
- Vehicles are set to expire after 7 days
- Expired vehicles are deleted on login / on use
- added a sanity check for killing mission mobs