### PR TITLE
Prevent player position from updating when flying on monkey

### DIFF
--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -183,11 +183,15 @@ void PlayerManager::updatePlayerPosition(CNSocket* sock, int X, int Y, int Z) {
     view.plr->x = X;
     view.plr->y = Y;
     view.plr->z = Z;
+    updatePlayerChunk(sock, X, Y);
+}
 
+void PlayerManager::updatePlayerChunk(CNSocket* sock, int X, int Y) {
+    PlayerView& view = players[sock];
     std::pair<int, int> newPos = ChunkManager::grabChunk(X, Y);
 
     // nothing to be done
-    if (newPos == view.chunkPos) 
+    if (newPos == view.chunkPos)
         return;
 
     // add player to chunk
@@ -195,10 +199,10 @@ void PlayerManager::updatePlayerPosition(CNSocket* sock, int X, int Y, int Z) {
 
     // first, remove all the old npcs & players from the old chunks
     removePlayerFromChunks(ChunkManager::getDeltaChunks(view.currentChunks, allChunks), sock);
-    
+
     // now, add all the new npcs & players!
     addPlayerToChunks(ChunkManager::getDeltaChunks(allChunks, view.currentChunks), sock);
-    
+
     ChunkManager::addPlayer(X, Y, sock); // takes care of adding the player to the chunk if it exists or not
     view.chunkPos = newPos;
     view.currentChunks = allChunks;

--- a/src/PlayerManager.hpp
+++ b/src/PlayerManager.hpp
@@ -32,6 +32,7 @@ namespace PlayerManager {
 
     void updatePlayerPosition(CNSocket* sock, int X, int Y, int Z);
     void updatePlayerPosition(CNSocket* sock, int X, int Y, int Z, int angle);
+    void updatePlayerChunk(CNSocket* sock, int X, int Y);
 
     void sendToViewable(CNSocket* sock, void* buf, uint32_t type, size_t size);
 

--- a/src/TransportManager.cpp
+++ b/src/TransportManager.cpp
@@ -238,7 +238,7 @@ void TransportManager::stepSkywaySystem() {
             bmstk.iToZ = point.z;
             it->first->sendPacket((void*)&bmstk, P_FE2CL_PC_BROOMSTICK_MOVE, sizeof(sP_FE2CL_PC_BROOMSTICK_MOVE));
             // set player location to point to update viewables
-            PlayerManager::updatePlayerPosition(it->first, point.x, point.y, point.z);
+            PlayerManager::updatePlayerChunk(it->first, point.x, point.y);
             // send packet to players in view
             PlayerManager::sendToViewable(it->first, (void*)&bmstk, P_FE2CL_PC_BROOMSTICK_MOVE, sizeof(sP_FE2CL_PC_BROOMSTICK_MOVE));
 


### PR DESCRIPTION
Now just the player's chunk is updated. This allows player and NPC visibility to be maintained, but without causing disconnected players to spawn in midair.