### PR TITLE
Fixed crash on killing summoned NPC

### DIFF
--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -8,6 +8,7 @@
 #include "contrib/JSON.hpp"
 
 #include <map>
+#include <queue>
 
 enum class MobState {
     INACTIVE,
@@ -83,6 +84,7 @@ struct Mob : public BaseNPC {
 
 namespace MobManager {
     extern std::map<int32_t, Mob*> Mobs;
+    extern std::queue<int32_t> RemovalQueue;
 
     void init();
     void step(CNServer*, time_t);


### PR DESCRIPTION
deadStep() was potentially modifying the mob map during automatic iteration. To avoid this, summoned mobs are queued for removal instead of being removed immediately. After the iteration in step, the queue is cleared and the map is modified then.