### PR TITLE
Fix nano buffs remaining after nano stamina runs out

### DIFF
--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -1,5 +1,6 @@
 #include "MobManager.hpp"
 #include "PlayerManager.hpp"
+#include "NanoManager.hpp"
 #include "NPCManager.hpp"
 #include "ItemManager.hpp"
 #include "MissionManager.hpp"
@@ -605,7 +606,7 @@ void MobManager::playerTick(CNServer *serv, time_t currTime) {
                    plr->Nanos[plr->activeNano].iStamina -= 1; 
 
                 if (plr->Nanos[plr->activeNano].iStamina < 0)
-                    plr->activeNano = 0;
+                    NanoManager::summonNano(PlayerManager::getSockFromID(plr->iID), -1);
 
                 transmit = true;
             } else if (plr->Nanos[plr->equippedNanos[i]].iStamina < 150) { // regain stamina

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -933,4 +933,12 @@ void PlayerManager::setSpecialState(CNSocket* sock, CNPacketData* data) {
     sock->sendPacket((void*)&response, P_FE2CL_REP_PC_SPECIAL_STATE_SWITCH_SUCC, sizeof(sP_FE2CL_REP_PC_SPECIAL_STATE_SWITCH_SUCC));
     sendToViewable(sock, (void*)&response, P_FE2CL_PC_SPECIAL_STATE_CHANGE, sizeof(sP_FE2CL_PC_SPECIAL_STATE_CHANGE));
 }
+
+CNSocket* PlayerManager::getSockFromID(int32_t iID) {
+    for (auto& pair : PlayerManager::players)
+        if (pair.second.plr->iID == iID)
+            return pair.first;
+
+    return nullptr;
+}
 #pragma endregion

--- a/src/PlayerManager.hpp
+++ b/src/PlayerManager.hpp
@@ -66,4 +66,5 @@ namespace PlayerManager {
     bool isAccountInUse(int accountId);
     void exitDuplicate(int accountId);
     void setSpecialState(CNSocket* sock, CNPacketData* data);
+    CNSocket* getSockFromID(int32_t iID);
 }


### PR DESCRIPTION
- Add helper function to PlayerManager to lookup player socket from iID (thanks Jade)
- Properly unsummon nano from within playerTick() when nano stamina runs out (bugfix)