### PR TITLE
Add MSS gruntwork commands

### DIFF
--- a/src/PlayerManager.hpp
+++ b/src/PlayerManager.hpp
@@ -34,6 +34,9 @@ namespace PlayerManager {
     void updatePlayerPosition(CNSocket* sock, int X, int Y, int Z, int angle);
     void updatePlayerChunk(CNSocket* sock, int X, int Y);
 
+    void sendPlayerTo(CNSocket* sock, int X, int Y, int Z, int I);
+    void sendPlayerTo(CNSocket* sock, int X, int Y, int Z);
+
     void sendToViewable(CNSocket* sock, void* buf, uint32_t type, size_t size);
 
     void enterPlayer(CNSocket* sock, CNPacketData* data);

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -12,6 +12,8 @@
 
 #include <fstream>
 
+std::map<int32_t, std::stack<WarpLocation>> TableData::RunningSkywayRoutes;
+
 void TableData::init() {
     int32_t nextId = 0;
 

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -12,7 +12,7 @@
 
 #include <fstream>
 
-std::map<int32_t, std::stack<WarpLocation>> TableData::RunningSkywayRoutes;
+std::map<int32_t, std::vector<WarpLocation>> TableData::RunningSkywayRoutes;
 
 void TableData::init() {
     int32_t nextId = 0;

--- a/src/TableData.hpp
+++ b/src/TableData.hpp
@@ -1,12 +1,11 @@
 #pragma once
 #include <map>
-#include <stack>
 
 #include "contrib/JSON.hpp"
 #include "NPCManager.hpp"
 
 namespace TableData {
-    extern std::map<int32_t, std::stack<WarpLocation>> RunningSkywayRoutes;
+    extern std::map<int32_t, std::vector<WarpLocation>> RunningSkywayRoutes;
 
     void init();
     void cleanup();

--- a/src/TableData.hpp
+++ b/src/TableData.hpp
@@ -1,9 +1,13 @@
 #pragma once
 #include <map>
+#include <stack>
 
 #include "contrib/JSON.hpp"
+#include "NPCManager.hpp"
 
 namespace TableData {
+    extern std::map<int32_t, std::stack<WarpLocation>> RunningSkywayRoutes;
+
     void init();
     void cleanup();
 


### PR DESCRIPTION
- Streamlined goto functionality
- Added vector map for temporary MSS routes in TableData
- Added basic commands for MSS gruntwork
-- /mss [route] add [height] :: adds a point in line with the player to the specified route
-- /mss [route] remove :: removes the last point added to the specified route
-- /mss [route] goto :: teleports the player to the last point added to the specified route
-- /mss [route] clear :: removes all points from the specified route
-- /mss [route] test :: moves the player along the route
-- /mss [route] export :: dumps the temporary route to JSON (TBC)