### PR TITLE
NPC Rotation Gruntwork

### DIFF
--- a/src/ChatManager.cpp
+++ b/src/ChatManager.cpp
@@ -223,6 +223,11 @@ void npcRotateCommand(std::string full, std::vector<std::string>& args, CNSocket
     ChatManager::sendServerMessage(sock, "[NPCR] Successfully set angle to " + std::to_string(angle) + " for NPC " + args[1]);
 }
 
+void refreshCommand(std::string full, std::vector<std::string>& args, CNSocket* sock) {
+    Player* plr = PlayerManager::getPlayer(sock);
+    PlayerManager::sendPlayerTo(sock, plr->x, plr->y, plr->z);
+}
+
 void flushCommand(std::string full, std::vector<std::string>& args, CNSocket* sock) {
     ChatManager::sendServerMessage(sock, "Wrote gruntwork to " + settings::GRUNTWORKJSON);
     TableData::flush();
@@ -241,6 +246,7 @@ void ChatManager::init() {
     registerCommand("flush", 30, flushCommand);
     registerCommand("level", 50, levelCommand);
     registerCommand("population", 100, populationCommand);
+    registerCommand("refresh", 100, refreshCommand);
 }
 
 void ChatManager::registerCommand(std::string cmd, int requiredLevel, CommandHandler handlr) {

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -134,6 +134,11 @@ void NPCManager::destroyNPC(int32_t id) {
     std::cout << "npc removed!" << std::endl;
 }
 
+void NPCManager::updateNPCPosition(int32_t id, int X, int Y, int Z, int angle) {
+    NPCs[id]->appearanceData.iAngle = angle;
+    updateNPCPosition(id, X, Y, Z);
+}
+
 void NPCManager::updateNPCPosition(int32_t id, int X, int Y, int Z) {
     BaseNPC* npc = NPCs[id];
 

--- a/src/NPCManager.hpp
+++ b/src/NPCManager.hpp
@@ -27,6 +27,7 @@ namespace NPCManager {
     void addNPC(std::vector<Chunk*> viewableChunks, int32_t id);
     void removeNPC(std::vector<Chunk*> viewableChunks, int32_t id);
     void destroyNPC(int32_t);
+    void updateNPCPosition(int32_t, int X, int Y, int Z, int angle);
     void updateNPCPosition(int32_t, int X, int Y, int Z);
 
     void sendToViewable(BaseNPC* npc, void* buf, uint32_t type, size_t size);

--- a/src/TableData.hpp
+++ b/src/TableData.hpp
@@ -6,6 +6,7 @@
 
 namespace TableData {
     extern std::map<int32_t, std::vector<WarpLocation>> RunningSkywayRoutes;
+    extern std::map<int32_t, int> RunningNPCRotations;
 
     void init();
     void cleanup();


### PR DESCRIPTION
- Add temporary NPC rotations and load/flush them from gruntwork JSON
- Add /npcr command
-- Makes the nearest NPC face the player
-- Stores the rotation in temporary memory to be flushed
- Add /refresh command
-- Teleports the player to the same spot, forcing the client to reload
- QoL: Add overload to updateNPCPosition() that accepts an angle as a parameter