### PR TITLE
functional crates (no more plungers)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -19,8 +19,9 @@ dbsaveinterval=240
 [shard]
 port=8002
 ip=127.0.0.1
-# distance at which other players and NPCs become visible
-chunksize=30000
+# distance at which other players and NPCs become visible.
+# this value is used for calculating chunk size
+viewdistance=30000
 # time, in milliseconds, to wait before kicking a non-responsive client
 # default is 1 minute
 timeout=60000

--- a/src/CNStructs.hpp
+++ b/src/CNStructs.hpp
@@ -34,6 +34,7 @@ std::string U16toU8(char16_t* src);
 size_t U8toU16(std::string src, char16_t* des, size_t max); // returns number of char16_t that was written at des
 time_t getTime();
 time_t getTimestamp();
+void terminate(int);
 
 // The PROTOCOL_VERSION definition is defined by the build system.
 #if !defined(PROTOCOL_VERSION)

--- a/src/ChatManager.cpp
+++ b/src/ChatManager.cpp
@@ -42,6 +42,17 @@ bool runCmd(std::string full, CNSocket* sock) {
     return false;
 }
 
+void helpCommand(std::string full, std::vector<std::string>& args, CNSocket* sock) {
+    ChatManager::sendServerMessage(sock, "Commands available to you");
+    Player *plr = PlayerManager::getPlayer(sock);
+    int i = 1;
+
+    for (auto& cmd : ChatManager::commands) {
+        if (cmd.second.requiredAccLevel >= plr->accountId)
+            ChatManager::sendServerMessage(sock, "/" + cmd.first + (cmd.second.help.length() > 0 ? " - " + cmd.second.help : ""));
+    }
+}
+
 void testCommand(std::string full, std::vector<std::string>& args, CNSocket* sock) {
     ChatManager::sendServerMessage(sock, "Test command is working! Here are your passed args:");
 
@@ -310,9 +321,9 @@ void ChatManager::init() {
     REGISTER_SHARD_PACKET(P_CL2FE_REQ_PC_AVATAR_EMOTES_CHAT, emoteHandler);
     REGISTER_SHARD_PACKET(P_CL2FE_REQ_SEND_MENUCHAT_MESSAGE, menuChatHandler);
 
+    registerCommand("help", 100, helpCommand, "lists all unlocked commands");
     registerCommand("test", 1, testCommand);
     registerCommand("access", 100, accessCommand);
-    // TODO: add help command
     registerCommand("mss", 30, mssCommand);
     registerCommand("npcr", 30, npcRotateCommand);
     registerCommand("summonW", 30, summonWCommand);
@@ -324,8 +335,8 @@ void ChatManager::init() {
     registerCommand("refresh", 100, refreshCommand);
 }
 
-void ChatManager::registerCommand(std::string cmd, int requiredLevel, CommandHandler handlr) {
-    commands[cmd] = ChatCommand(requiredLevel, handlr);
+void ChatManager::registerCommand(std::string cmd, int requiredLevel, CommandHandler handlr, std::string help) {
+    commands[cmd] = ChatCommand(requiredLevel, handlr, help);
 }
 
 void ChatManager::chatHandler(CNSocket* sock, CNPacketData* data) {

--- a/src/ChatManager.cpp
+++ b/src/ChatManager.cpp
@@ -279,10 +279,18 @@ void toggleAiCommand(std::string full, std::vector<std::string>& args, CNSocket*
     for (auto& pair : MobManager::Mobs) {
         pair.second->state = MobState::RETREAT;
         pair.second->target = nullptr;
+        pair.second->nextMovement = getTime();
 
-        pair.second->roamX = pair.second->spawnX;
-        pair.second->roamY = pair.second->spawnY;
-        pair.second->roamZ = pair.second->spawnZ;
+        // mobs with static paths can chill where they are
+        if (pair.second->staticPath) {
+            pair.second->roamX = pair.second->appearanceData.iX;
+            pair.second->roamY = pair.second->appearanceData.iY;
+            pair.second->roamZ = pair.second->appearanceData.iZ;
+        } else {
+            pair.second->roamX = pair.second->spawnX;
+            pair.second->roamY = pair.second->spawnY;
+            pair.second->roamZ = pair.second->spawnZ;
+        }
     }
 }
 

--- a/src/ChatManager.cpp
+++ b/src/ChatManager.cpp
@@ -45,7 +45,6 @@ bool runCmd(std::string full, CNSocket* sock) {
 void helpCommand(std::string full, std::vector<std::string>& args, CNSocket* sock) {
     ChatManager::sendServerMessage(sock, "Commands available to you");
     Player *plr = PlayerManager::getPlayer(sock);
-    int i = 1;
 
     for (auto& cmd : ChatManager::commands) {
         if (cmd.second.requiredAccLevel >= plr->accountId)
@@ -280,6 +279,10 @@ void toggleAiCommand(std::string full, std::vector<std::string>& args, CNSocket*
     for (auto& pair : MobManager::Mobs) {
         pair.second->state = MobState::RETREAT;
         pair.second->target = nullptr;
+
+        pair.second->roamX = pair.second->spawnX;
+        pair.second->roamY = pair.second->spawnY;
+        pair.second->roamZ = pair.second->spawnZ;
     }
 }
 

--- a/src/ChatManager.cpp
+++ b/src/ChatManager.cpp
@@ -226,7 +226,7 @@ void summonWCommand(std::string full, std::vector<std::string>& args, CNSocket* 
 
     BaseNPC *npc = nullptr;
     if (team == 2) {
-        npc = new Mob(plr->x, plr->y, plr->z, plr->instanceID, type, NPCManager::NPCData[type], NPCManager::nextId++);
+        npc = new Mob(plr->x, plr->y, plr->z + 1000, plr->instanceID, type, NPCManager::NPCData[type], NPCManager::nextId++);
         npc->appearanceData.iAngle = (plr->angle + 180) % 360;
 
         NPCManager::NPCs[npc->appearanceData.iNPC_ID] = npc;

--- a/src/ChatManager.hpp
+++ b/src/ChatManager.hpp
@@ -8,9 +8,11 @@ typedef void (*CommandHandler)(std::string fullString, std::vector<std::string>&
 
 struct ChatCommand {
     int requiredAccLevel;
+    std::string help;
     CommandHandler handlr;
 
     ChatCommand(int r, CommandHandler h): requiredAccLevel(r), handlr(h) {}
+    ChatCommand(int r, CommandHandler h, std::string str): requiredAccLevel(r), help(str), handlr(h) {}
     ChatCommand(): ChatCommand(0, nullptr) {}
 };
 
@@ -18,7 +20,7 @@ namespace ChatManager {
     extern std::map<std::string, ChatCommand> commands;
     void init();
 
-    void registerCommand(std::string cmd, int requiredLevel, CommandHandler handlr);
+    void registerCommand(std::string cmd, int requiredLevel, CommandHandler handlr, std::string help = "");
 
     void chatHandler(CNSocket* sock, CNPacketData* data);
     void emoteHandler(CNSocket* sock, CNPacketData* data);

--- a/src/ChunkManager.cpp
+++ b/src/ChunkManager.cpp
@@ -109,7 +109,7 @@ bool ChunkManager::checkChunk(std::tuple<int, int, int> chunk) {
 }
 
 std::tuple<int, int, int> ChunkManager::grabChunk(int posX, int posY, int instanceID) {
-    return std::make_tuple(posX / (settings::CHUNKSIZE / 3), posY / (settings::CHUNKSIZE / 3), instanceID);
+    return std::make_tuple(posX / (settings::VIEWDISTANCE / 3), posY / (settings::VIEWDISTANCE / 3), instanceID);
 }
 
 std::vector<Chunk*> ChunkManager::grabChunks(std::tuple<int, int, int> chunk) {

--- a/src/ChunkManager.hpp
+++ b/src/ChunkManager.hpp
@@ -31,6 +31,7 @@ namespace ChunkManager {
     void removePlayer(std::tuple<int, int, int> chunkPos, CNSocket* sock);
     void removeNPC(std::tuple<int, int, int> chunkPos, int32_t id);
     bool checkChunk(std::tuple<int, int, int> chunk);
+    void destroyChunk(std::tuple<int, int, int> chunkPos);
     std::tuple<int, int, int> grabChunk(int posX, int posY, int instanceID);
     std::vector<Chunk*> grabChunks(std::tuple<int, int, int> chunkPos);
     std::vector<Chunk*> getDeltaChunks(std::vector<Chunk*> from, std::vector<Chunk*> to);

--- a/src/GroupManager.cpp
+++ b/src/GroupManager.cpp
@@ -3,6 +3,7 @@
 #include "ChatManager.hpp"
 #include "PlayerManager.hpp"
 #include "GroupManager.hpp"
+#include "NanoManager.hpp"
 
 #include <iostream>
 #include <chrono>
@@ -93,7 +94,7 @@ void GroupManager::joinGroup(CNSocket* sock, CNPacketData* data) {
     if (otherPlr == nullptr)
 		return;
 
-    // fail if the group is full the other player is already in a group
+    // fail if the group is full or the other player is already in a group
     if (plr->groupCnt > 1 || plr->iIDGroup != plr->iID || otherPlr->groupCnt >= 4) {
         INITSTRUCT(sP_FE2CL_PC_GROUP_JOIN_FAIL, resp);
         sock->sendPacket((void*)&resp, P_FE2CL_PC_GROUP_JOIN_FAIL, sizeof(sP_FE2CL_PC_GROUP_JOIN_FAIL));
@@ -104,6 +105,8 @@ void GroupManager::joinGroup(CNSocket* sock, CNPacketData* data) {
         std::cout << "[WARN] bad sP_FE2CL_PC_GROUP_JOIN packet size\n";
         return;
     }
+    
+    int bitFlagBefore = getGroupFlags(otherPlr);
 
     plr->iIDGroup = otherPlr->iID;
     otherPlr->groupCnt += 1;
@@ -119,11 +122,14 @@ void GroupManager::joinGroup(CNSocket* sock, CNPacketData* data) {
 
     resp->iID_NewMember = plr->iID;
     resp->iMemberPCCnt = otherPlr->groupCnt;
+    
+    int bitFlag = getGroupFlags(otherPlr);
 
     for (int i = 0; i < otherPlr->groupCnt; i++) {
         Player* varPlr = PlayerManager::getPlayerFromID(otherPlr->groupIDs[i]);
+        CNSocket* sockTo = PlayerManager::getSockFromID(otherPlr->groupIDs[i]);
 
-        if (varPlr == nullptr)
+        if (varPlr == nullptr || sockTo == nullptr)
             continue;
 
         respdata[i].iPC_ID = varPlr->iID;
@@ -141,8 +147,10 @@ void GroupManager::joinGroup(CNSocket* sock, CNPacketData* data) {
         respdata[i].iY = varPlr->y;
         respdata[i].iZ = varPlr->z;
         // client doesnt read nano data here
+        
+        NanoManager::nanoChangeBuff(sockTo, varPlr, bitFlagBefore | varPlr->iConditionBitFlag, bitFlag | varPlr->iConditionBitFlag);
     }
-
+    
     sendToGroup(otherPlr, (void*)&respbuf, P_FE2CL_PC_GROUP_JOIN, resplen);
 }
 
@@ -228,10 +236,10 @@ void GroupManager::groupTickInfo(Player* plr) {
 
     for (int i = 0; i < plr->groupCnt; i++) {
         Player* varPlr = PlayerManager::getPlayerFromID(plr->groupIDs[i]);
-
+        
         if (varPlr == nullptr)
             continue;
-
+        
         respdata[i].iPC_ID = varPlr->iID;
         respdata[i].iPCUID = varPlr->PCStyle.iPC_UID;
         respdata[i].iNameCheck = varPlr->PCStyle.iNameCheck;
@@ -255,9 +263,10 @@ void GroupManager::groupTickInfo(Player* plr) {
     sendToGroup(plr, (void*)&respbuf, P_FE2CL_PC_GROUP_MEMBER_INFO, resplen);
 }
 
-void GroupManager::groupKickPlayer(Player* plr) {
+void GroupManager::groupKickPlayer(Player* plr) {    
     // if you are the group leader, destroy your own group and kick everybody
     if (plr->iID == plr->iIDGroup) {
+        groupUnbuff(plr);
         INITSTRUCT(sP_FE2CL_PC_GROUP_LEAVE_SUCC, resp1);
         sendToGroup(plr, (void*)&resp1, P_FE2CL_PC_GROUP_LEAVE_SUCC, sizeof(sP_FE2CL_PC_GROUP_LEAVE_SUCC));
         plr->groupCnt = 1;
@@ -273,7 +282,7 @@ void GroupManager::groupKickPlayer(Player* plr) {
         std::cout << "[WARN] bad sP_FE2CL_PC_GROUP_LEAVE packet size\n";
         return;
     }
-
+    
     size_t resplen = sizeof(sP_FE2CL_PC_GROUP_LEAVE) + (otherPlr->groupCnt - 1) * sizeof(sPCGroupMemberInfo);
     uint8_t respbuf[CN_PACKET_BUFFER_SIZE];
 
@@ -285,12 +294,15 @@ void GroupManager::groupKickPlayer(Player* plr) {
     resp->iID_LeaveMember = plr->iID;
     resp->iMemberPCCnt = otherPlr->groupCnt - 1;
 
+    int bitFlagBefore = getGroupFlags(otherPlr);
+    int bitFlag = bitFlagBefore & ~plr->iGroupConditionBitFlag;
     int moveDown = 0;
 
     for (int i = 0; i < otherPlr->groupCnt; i++) {
         Player* varPlr = PlayerManager::getPlayerFromID(otherPlr->groupIDs[i]);
+        CNSocket* sockTo = PlayerManager::getSockFromID(otherPlr->groupIDs[i]);
 
-        if (varPlr == nullptr)
+        if (varPlr == nullptr || sockTo == nullptr)
             continue;
 
         if (moveDown == 1)
@@ -315,14 +327,16 @@ void GroupManager::groupKickPlayer(Player* plr) {
         if (varPlr == plr) {
             moveDown = 1;
             otherPlr->groupIDs[i] = 0;
-        }
+            NanoManager::nanoChangeBuff(sockTo, varPlr, bitFlagBefore | varPlr->iConditionBitFlag, varPlr->iConditionBitFlag);
+        } else
+            NanoManager::nanoChangeBuff(sockTo, varPlr, bitFlagBefore | varPlr->iConditionBitFlag, bitFlag | varPlr->iConditionBitFlag);
     }
 
     plr->iIDGroup = plr->iID;
     otherPlr->groupCnt -= 1;
-
+    
     sendToGroup(otherPlr, (void*)&respbuf, P_FE2CL_PC_GROUP_LEAVE, resplen);
-
+    
     CNSocket* sock = PlayerManager::getSockFromID(plr->iID);
 
     if (sock == nullptr)
@@ -330,4 +344,33 @@ void GroupManager::groupKickPlayer(Player* plr) {
 
     INITSTRUCT(sP_FE2CL_PC_GROUP_LEAVE_SUCC, resp1);
     sock->sendPacket((void*)&resp1, P_FE2CL_PC_GROUP_LEAVE_SUCC, sizeof(sP_FE2CL_PC_GROUP_LEAVE_SUCC));
+}
+
+void GroupManager::groupUnbuff(Player* plr) {
+    int bitFlag = getGroupFlags(plr);
+    
+    for (int i = 0; i < plr->groupCnt; i++) {
+        CNSocket* sock = PlayerManager::getSockFromID(plr->groupIDs[i]);
+        
+        if (sock == nullptr)
+            continue;
+        
+        Player* otherPlr = PlayerManager::getPlayer(sock);
+        NanoManager::nanoChangeBuff(sock, otherPlr, bitFlag | otherPlr->iConditionBitFlag, otherPlr->iConditionBitFlag);
+    }
+}
+
+int GroupManager::getGroupFlags(Player* plr) {
+    int bitFlag = 0;
+    
+    for (int i = 0; i < plr->groupCnt; i++) {
+        Player* otherPlr = PlayerManager::getPlayerFromID(plr->groupIDs[i]);
+        
+        if (otherPlr == nullptr)
+            continue;
+        
+        bitFlag |= otherPlr->iGroupConditionBitFlag; 
+    }
+    
+    return bitFlag;
 }

--- a/src/GroupManager.hpp
+++ b/src/GroupManager.hpp
@@ -20,4 +20,6 @@ namespace GroupManager {
     void sendToGroup(Player* plr, void* buf, uint32_t type, size_t size);
     void groupTickInfo(Player* plr);
     void groupKickPlayer(Player* plr);
+    void groupUnbuff(Player* plr);
+    int getGroupFlags(Player* plr);
 }

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -961,7 +961,8 @@ sItemBase ItemManager::getCrateItem(int itemSetId, int rarity, int playerGender)
 
 // argument is here only so we can call sprintf in brackets
 void ItemManager::throwError(int ignore) {
-    throw (std::exception(buffer));
+    const char* message = buffer;
+    throw (std::exception(message));
 }
 
 // TODO: use this in cleaned up ItemManager

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -888,7 +888,7 @@ int ItemManager::getItemSetId(Crate crate, int crateId) {
         throwError(sprintf(buffer, "Crate %d has no item sets assigned?!", crateId));
 
     // if crate points to multiple itemSets, choose a random one
-        int itemSetIndex = rand() % itemSetsCount;
+    int itemSetIndex = rand() % itemSetsCount;
     return crate.itemSets[itemSetIndex];
 }
 

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -211,6 +211,11 @@ void ItemManager::itemGMGiveHandler(CNSocket* sock, CNPacketData* data) {
 
         resp.eIL = itemreq->eIL;
         resp.iSlotNum = itemreq->iSlotNum;
+        if (itemreq->Item.iType == 10) {
+            // item is vehicle, set expiration date
+            // set time limit: current time + 7days
+            itemreq->Item.iTimeLimit = getTimestamp() + 604800;
+        }
         resp.Item = itemreq->Item;
 
         plr.plr->Inven[itemreq->iSlotNum] = itemreq->Item;

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -961,8 +961,7 @@ sItemBase ItemManager::getCrateItem(int itemSetId, int rarity, int playerGender)
 
 // argument is here only so we can call sprintf in brackets
 void ItemManager::throwError(int ignore) {
-    const char* message = buffer;
-    throw (std::exception(message));
+    throw buffer;
 }
 
 // TODO: use this in cleaned up ItemManager

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -949,7 +949,7 @@ sItemBase ItemManager::getCrateItem(int itemSetId, int rarity, int playerGender)
     }
 
     if (items.size() == 0)
-        throwError(sprintf(buffer, "Gender inequality! Set ID %d Rarity %d contains only %s items?!", itemSetId, rarity, playerGender==1 ? "boys" : "girls"));
+        throwError(sprintf(buffer, "Gender inequality! Set ID %d Rarity %d contains only %s items?!", itemSetId, rarity, playerGender==2 ? "boys" : "girls"));
     auto item = items[rand() % items.size()];
     sItemBase result = {};
     result.iID = item->first.first;

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -5,7 +5,7 @@
 #include "NanoManager.hpp"
 #include "Player.hpp"
 
-#include <string.h> // for memset() and memcmp()
+#include <string.h> // for memset()
 #include <assert.h>
 
 std::map<std::pair<int32_t, int32_t>, Item> ItemManager::ItemData;
@@ -911,6 +911,10 @@ void ItemManager::setItemStats(Player* plr) {
 
     for (int i = 0; i < 4; i++) {
         itemStatsDat = ItemManager::getItemData(plr->Equip[i].iID, plr->Equip[i].iType);
+        if (itemStatsDat == nullptr) {
+            std::cout << "[WARN] setItemStats(): getItemData() returned NULL" << std::endl;
+            continue;
+        }
         plr->pointDamage += itemStatsDat->pointDamage;
         plr->groupDamage += itemStatsDat->groupDamage;
         plr->defense += itemStatsDat->defense;

--- a/src/ItemManager.hpp
+++ b/src/ItemManager.hpp
@@ -5,7 +5,7 @@
 
 struct Item {
     bool tradeable, sellable;
-    int buyPrice, sellPrice, stackSize, level, rarity, pointDamage, groupDamage, defense; // TODO: implement more as needed
+    int buyPrice, sellPrice, stackSize, level, rarity, pointDamage, groupDamage, defense, gender; // TODO: implement more as needed
 };
 struct VendorListing {
     int sort, type, iID;
@@ -13,6 +13,10 @@ struct VendorListing {
 struct CrocPotEntry {
     int multStats, multLooks;
     float base, rd0, rd1, rd2, rd3;
+};
+struct Crate {
+    int rarityRatioId;
+    std::vector<int> itemSets;
 };
 
 namespace ItemManager {
@@ -25,6 +29,11 @@ namespace ItemManager {
     extern std::map<std::pair<int32_t, int32_t>, Item> ItemData; // <id, type> -> data
     extern std::map<int32_t, std::vector<VendorListing>> VendorTables;
     extern std::map<int32_t, CrocPotEntry> CrocPotTable; // level gap -> entry
+    extern std::map<int32_t, std::vector<int>> RarityRatios; 
+    extern std::map<int32_t, Crate> Crates;
+    // pair <Itemset, Rarity> -> vector of pointers (map iterators) to records in ItemData (it looks a lot scarier than it is)
+    extern std::map<std::pair<int32_t, int32_t>, 
+        std::vector<std::map<std::pair<int32_t, int32_t>, Item>::iterator>> CrateItems; 
 
     void init();
 
@@ -45,6 +54,14 @@ namespace ItemManager {
     void itemTradeRegisterCashHandler(CNSocket* sock, CNPacketData* data);
     void itemTradeChatHandler(CNSocket* sock, CNPacketData* data);
     void chestOpenHandler(CNSocket* sock, CNPacketData* data);
+
+    // crate opening logic with all helper functions
+    sItemBase openCrate(int crateId, int playerGender);
+    Crate getCrate(int crateId);
+    int getItemSetId(Crate crate, int crateId);
+    int getRarity(Crate crate, int itemSetId);
+    sItemBase getCrateItem(int itemSetId, int rarity, int playerGender);
+    void throwError(int ignore);
 
     int findFreeSlot(Player *plr);
     Item* getItemData(int32_t id, int32_t type);

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -367,7 +367,7 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
     }
 }
 
-inline void MobManager::incNextMovement(Mob *mob, time_t currTime) {
+void MobManager::incNextMovement(Mob *mob, time_t currTime) {
     if (currTime == 0)
         currTime = getTime();
 
@@ -398,8 +398,6 @@ void MobManager::roamingStep(Mob *mob, time_t currTime) {
     auto it = TransportManager::NPCQueues.find(mob->appearanceData.iNPC_ID);
     if (it != TransportManager::NPCQueues.end() && it->second.empty())
         return;
-
-    std::cout << "charting new path for Mob " << (int)mob->appearanceData.iNPC_ID << std::endl;
 
     int xStart = mob->spawnX - mob->idleRange/2;
     int yStart = mob->spawnY - mob->idleRange/2;

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -75,9 +75,16 @@ void MobManager::pcAttackNpcs(CNSocket *sock, CNPacketData *data) {
         std::pair<int,int> damage;
 
         if (pkt->iNPCCnt > 1)
-            damage = getDamage(plr->groupDamage, (int)mob->data["m_iProtection"], true, (int)mob->data["m_iNpcLevel"]);
+            damage.first = plr->groupDamage;
         else
-            damage = getDamage(plr->pointDamage, (int)mob->data["m_iProtection"], true, (int)mob->data["m_iNpcLevel"]);
+            damage.first = plr->pointDamage;
+        
+        int difficulty = (int)mob->data["m_iNpcLevel"];
+        
+        damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW >= 11 + difficulty), NanoManager::nanoStyle(plr->activeNano), (int)mob->data["m_iNpcStyle"], difficulty);
+        
+        if (plr->batteryW >= 11 + difficulty)
+            plr->batteryW -= 11 + difficulty;
 
         damage.first = hitMob(sock, mob, damage.first);
 
@@ -114,7 +121,7 @@ void MobManager::npcAttackPc(Mob *mob, time_t currTime) {
     sP_FE2CL_NPC_ATTACK_PCs *pkt = (sP_FE2CL_NPC_ATTACK_PCs*)respbuf;
     sAttackResult *atk = (sAttackResult*)(respbuf + sizeof(sP_FE2CL_NPC_ATTACK_PCs));
 
-    auto damage = getDamage(470 + (int)mob->data["m_iPower"], plr->defense, false, 1);
+    auto damage = getDamage(475 + (int)mob->data["m_iPower"], plr->defense, false, false, -1, -1, 1);
     plr->HP -= damage.first;
 
     pkt->iNPC_ID = mob->appearanceData.iNPC_ID;
@@ -224,8 +231,26 @@ void MobManager::killMob(CNSocket *sock, Mob *mob) {
 
     // check for the edge case where hitting the mob did not aggro it
     if (sock != nullptr) {
-        giveReward(sock);
-        MissionManager::mobKilled(sock, mob->appearanceData.iNPCType);
+        Player* plr = PlayerManager::getPlayer(sock);
+        
+        if (plr == nullptr)
+            return;
+        
+        if (plr->groupCnt == 1 && plr->iIDGroup == plr->iID) { 
+            giveReward(sock);
+            MissionManager::mobKilled(sock, mob->appearanceData.iNPCType);
+        } else {
+            plr = PlayerManager::getPlayerFromID(plr->iIDGroup);
+
+            if (plr == nullptr)
+                return;
+            
+            for (int i = 0; i < plr->groupCnt; i++) {
+                CNSocket* sockTo = PlayerManager::getSockFromID(plr->groupIDs[i]);
+                giveReward(sockTo);
+                MissionManager::mobKilled(sockTo, mob->appearanceData.iNPCType);
+            }
+        }
     }
 
     mob->despawned = false;
@@ -677,12 +702,26 @@ void MobManager::playerTick(CNServer *serv, time_t currTime) {
         lastHealTime = currTime;
 }
 
-std::pair<int,int> MobManager::getDamage(int attackPower, int defensePower, bool shouldCrit, int crutchLevel) {
+std::pair<int,int> MobManager::getDamage(int attackPower, int defensePower, bool shouldCrit, bool batteryBoost, int attackerStyle, int defenderStyle, int difficulty) {
+    std::pair<int,int> ret = {0, 1};
+    if (attackPower + defensePower * 2 == 0)
+        return ret;
 
-    std::pair<int,int> ret = {};
-
-    int damage = (std::max(40, attackPower - defensePower) * (34 + crutchLevel) + std::min(attackPower, attackPower * attackPower / defensePower) * (36 - crutchLevel)) / 70;
-    ret.first = damage * (rand() % 40 + 80) / 100; // 20% variance
+    int damage = attackPower * attackPower / (attackPower + defensePower);
+    damage = std::max(std::max(29, attackPower / 7), damage - defensePower * (12 + difficulty) / 65);
+    damage = damage * (rand() % 40 + 80) / 100;
+    
+    if (attackerStyle != -1 && defenderStyle != -1 && attackerStyle != defenderStyle) {
+        if (attackerStyle < defenderStyle || attackerStyle - defenderStyle == 2) 
+            damage = damage * 5 / 4;
+        else
+            damage = damage * 4 / 5;
+    }
+    
+    if (batteryBoost)
+        damage = damage * 5 / 4;
+    
+    ret.first = damage;
     ret.second = 1;
 
     if (shouldCrit && rand() % 20 == 0) {
@@ -744,9 +783,14 @@ void MobManager::pcAttackChars(CNSocket *sock, CNPacketData *data) {
             std::pair<int,int> damage;
 
             if (pkt->iTargetCnt > 1)
-                damage = getDamage(plr->groupDamage, target->defense, true, 1);
+                damage.first = plr->groupDamage;
             else
-                damage = getDamage(plr->pointDamage, target->defense, true, 1);
+                damage.first = plr->pointDamage;
+        
+            damage = getDamage(damage.first, target->defense, true, (plr->batteryW >= 12), -1, -1, 1);
+        
+            if (plr->batteryW >= 12)
+                plr->batteryW -= 12;
 
             target->HP -= damage.first;
 
@@ -766,9 +810,16 @@ void MobManager::pcAttackChars(CNSocket *sock, CNPacketData *data) {
             std::pair<int,int> damage;
 
             if (pkt->iTargetCnt > 1)
-                damage = getDamage(plr->groupDamage, (int)mob->data["m_iProtection"], true, (int)mob->data["m_iNpcLevel"]);
+                damage.first = plr->groupDamage;
             else
-                damage = getDamage(plr->pointDamage, (int)mob->data["m_iProtection"], true, (int)mob->data["m_iNpcLevel"]);
+                damage.first = plr->pointDamage;
+            
+            int difficulty = (int)mob->data["m_iNpcLevel"];
+            
+            damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW >= 11 + difficulty), NanoManager::nanoStyle(plr->activeNano), (int)mob->data["m_iNpcStyle"], difficulty);
+            
+            if (plr->batteryW >= 11 + difficulty)
+                plr->batteryW -= 11 + difficulty;
 
             damage.first = hitMob(sock, mob, damage.first);
 
@@ -783,7 +834,7 @@ void MobManager::pcAttackChars(CNSocket *sock, CNPacketData *data) {
     sock->sendPacket((void*)respbuf, P_FE2CL_PC_ATTACK_CHARs_SUCC, resplen);
 
     // a bit of a hack: these are the same size, so we can reuse the response packet
-    assert(sizeof(sP_FE2CL_PC_ATTACK_NPCs_SUCC) == sizeof(sP_FE2CL_PC_ATTACK_CHARs));
+    assert(sizeof(sP_FE2CL_PC_ATTACK_CHARs_SUCC) == sizeof(sP_FE2CL_PC_ATTACK_CHARs));
     sP_FE2CL_PC_ATTACK_CHARs *resp1 = (sP_FE2CL_PC_ATTACK_CHARs*)respbuf;
 
     resp1->iPC_ID = plr->iID;

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -40,6 +40,7 @@ struct Mob : public BaseNPC {
     // combat
     CNSocket *target = nullptr;
     time_t nextAttack = 0;
+    int roamX, roamY, roamZ;
 
     // temporary; until we're sure what's what
     nlohmann::json data;
@@ -57,9 +58,9 @@ struct Mob : public BaseNPC {
         if (regenTime >= 300000000)
             regenTime = 1500;
 
-        spawnX = appearanceData.iX;
-        spawnY = appearanceData.iY;
-        spawnZ = appearanceData.iZ;
+        roamX = spawnX = appearanceData.iX;
+        roamY = spawnY = appearanceData.iY;
+        roamZ = spawnZ = appearanceData.iZ;
 
         appearanceData.iConditionBitFlag = 0;
 

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -35,6 +35,7 @@ struct Mob : public BaseNPC {
     // roaming
     int idleRange;
     time_t nextMovement = 0;
+    bool staticPath = false;
 
     // combat
     CNSocket *target = nullptr;
@@ -50,7 +51,7 @@ struct Mob : public BaseNPC {
         data = d;
 
         regenTime = data["m_iRegenTime"];
-        idleRange = data["m_iIdleRange"];
+        idleRange = (int)data["m_iIdleRange"] * 2; // TODO: tuning?
 
         // XXX: temporarily force respawns for Fusions until we implement instancing
         if (regenTime >= 300000000)
@@ -111,5 +112,6 @@ namespace MobManager {
 
     void pcAttackChars(CNSocket *sock, CNPacketData *data);
     void resendMobHP(Mob *mob);
+    void incNextMovement(Mob *mob, time_t currTime=0);
     bool aggroCheck(Mob *mob, time_t currTime);
 }

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -25,6 +25,7 @@ struct Mob : public BaseNPC {
     int spawnX;
     int spawnY;
     int spawnZ;
+    int level;
 
     // dead
     time_t killedTime = 0;
@@ -42,6 +43,9 @@ struct Mob : public BaseNPC {
     time_t nextAttack = 0;
     int roamX, roamY, roamZ;
 
+    //drop
+    int dropType;
+
     // temporary; until we're sure what's what
     nlohmann::json data;
 
@@ -53,6 +57,8 @@ struct Mob : public BaseNPC {
 
         regenTime = data["m_iRegenTime"];
         idleRange = (int)data["m_iIdleRange"] * 2; // TODO: tuning?
+        dropType = data["m_iDropType"];
+        level = data["m_iNpcLevel"];
 
         // XXX: temporarily force respawns for Fusions until we implement instancing
         if (regenTime >= 300000000)
@@ -84,9 +90,24 @@ struct Mob : public BaseNPC {
     }
 };
 
+struct MobDropChance {
+    int dropChance;
+    std::vector<int> cratesRatio;
+};
+
+struct MobDrop {
+    std::vector<int> crateIDs;
+    int dropChanceType;
+    int taros;
+    int fm;
+    int boosts;
+};
+
 namespace MobManager {
     extern std::map<int32_t, Mob*> Mobs;
     extern std::queue<int32_t> RemovalQueue;
+    extern std::map<int32_t, MobDropChance> MobDropChances;
+    extern std::map<int32_t, MobDrop> MobDrops;
     extern bool simulateMobs;
 
     void init();
@@ -107,7 +128,10 @@ namespace MobManager {
     void npcAttackPc(Mob *mob, time_t currTime);
     int hitMob(CNSocket *sock, Mob *mob, int damage);
     void killMob(CNSocket *sock, Mob *mob);
-    void giveReward(CNSocket *sock);
+    void giveReward(CNSocket *sock, Mob *mob);
+    sItemBase getReward(MobDrop *drop, MobDropChance *chance);
+    void giveEventReward(CNSocket* sock, Player* player);
+
     std::pair<int,int> lerp(int, int, int, int, int);
     std::pair<int,int> getDamage(int, int, bool, bool, int, int, int);
 

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -45,8 +45,8 @@ struct Mob : public BaseNPC {
     // temporary; until we're sure what's what
     nlohmann::json data;
 
-    Mob(int x, int y, int z, int iID, int type, int hp, int angle, nlohmann::json d, int32_t id)
-        : BaseNPC(x, y, z, iID, type, id), maxHealth(hp) {
+    Mob(int x, int y, int z, int angle, int iID, int type, int hp, nlohmann::json d, int32_t id)
+        : BaseNPC(x, y, z, angle, iID, type, id), maxHealth(hp) {
         state = MobState::ROAMING;
 
         data = d;
@@ -72,7 +72,7 @@ struct Mob : public BaseNPC {
 
     // constructor for /summon
     Mob(int x, int y, int z, int iID, int type, nlohmann::json d, int32_t id)
-        : Mob(x, y, z, iID, type, 0, 0, d, id) {
+        : Mob(x, y, z, 0, iID, type, 0, d, id) {
         summoned = true; // will be despawned and deallocated when killed
         appearanceData.iHP = maxHealth = d["m_iHP"];
     }

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -107,7 +107,7 @@ namespace MobManager {
     void killMob(CNSocket *sock, Mob *mob);
     void giveReward(CNSocket *sock);
     std::pair<int,int> lerp(int, int, int, int, int);
-    std::pair<int,int> getDamage(int, int, bool, int);
+    std::pair<int,int> getDamage(int, int, bool, bool, int, int, int);
 
     void pcAttackChars(CNSocket *sock, CNPacketData *data);
     void resendMobHP(Mob *mob);

--- a/src/NPC.hpp
+++ b/src/NPC.hpp
@@ -12,13 +12,13 @@ public:
     std::vector<Chunk*> currentChunks;
 
     BaseNPC() {};
-    BaseNPC(int x, int y, int z, int iID, int type, int id) {
+    BaseNPC(int x, int y, int z, int angle, int iID, int type, int id) {
         appearanceData.iX = x;
         appearanceData.iY = y;
         appearanceData.iZ = z;
         appearanceData.iNPCType = type;
         appearanceData.iHP = 400;
-        appearanceData.iAngle = 0;
+        appearanceData.iAngle = angle;
         appearanceData.iConditionBitFlag = 0;
         appearanceData.iBarkerType = 0;
         appearanceData.iNPC_ID = id;
@@ -27,7 +27,7 @@ public:
 
         chunkPos = std::make_tuple(0, 0, instanceID);
     };
-    BaseNPC(int x, int y, int z, int iID, int type, int id, NPCClass classType) : BaseNPC(x, y, z, iID, type, id) {
+    BaseNPC(int x, int y, int z, int angle, int iID, int type, int id, NPCClass classType) : BaseNPC(x, y, z, angle, iID, type, id) {
         npcClass = classType;
     }
 };

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -548,7 +548,7 @@ void NPCManager::npcSummonHandler(CNSocket* sock, CNPacketData* data) {
             NPCs[id] = new Mob(plr->x, plr->y, plr->z, plr->instanceID, req->iNPCType, NPCData[req->iNPCType], id);
             MobManager::Mobs[id] = (Mob*)NPCs[id];
         } else
-            NPCs[id] = new BaseNPC(plr->x, plr->y, plr->z, plr->instanceID, req->iNPCType, id);
+            NPCs[id] = new BaseNPC(plr->x, plr->y, plr->z, 0, plr->instanceID, req->iNPCType, id);
 
         updateNPCPosition(id, plr->x, plr->y, plr->z);
     }

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -535,21 +535,23 @@ void NPCManager::npcSummonHandler(CNSocket* sock, CNPacketData* data) {
     Player* plr = PlayerManager::getPlayer(sock);
 
     // permission & sanity check
-    if (plr == nullptr || plr->accountLevel > 30 || req->iNPCType >= 3314)
+    if (plr == nullptr || plr->accountLevel > 30 || req->iNPCType >= 3314 || req->iNPCCnt > 100)
         return;
 
     int team = NPCData[req->iNPCType]["m_iTeam"];
 
-    assert(nextId < INT32_MAX);
-    int id = nextId++;
+    for (int i = 0; i < req->iNPCCnt; i++) {
+        assert(nextId < INT32_MAX);
+        int id = nextId++;
 
-    if (team == 2) {
-        NPCs[id] = new Mob(plr->x, plr->y, plr->z, plr->instanceID, req->iNPCType, NPCData[req->iNPCType], id);
-        MobManager::Mobs[id] = (Mob*)NPCs[id];
-    } else
-        NPCs[id] = new BaseNPC(plr->x, plr->y, plr->z, plr->instanceID, req->iNPCType, id);
+        if (team == 2) {
+            NPCs[id] = new Mob(plr->x, plr->y, plr->z, plr->instanceID, req->iNPCType, NPCData[req->iNPCType], id);
+            MobManager::Mobs[id] = (Mob*)NPCs[id];
+        } else
+            NPCs[id] = new BaseNPC(plr->x, plr->y, plr->z, plr->instanceID, req->iNPCType, id);
 
-    updateNPCPosition(id, plr->x, plr->y, plr->z);
+        updateNPCPosition(id, plr->x, plr->y, plr->z);
+    }
 }
 
 void NPCManager::npcWarpHandler(CNSocket* sock, CNPacketData* data) {

--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -625,9 +625,9 @@ void activePower(CNSocket *sock, CNPacketData *data,
             return;
 
         pkt->iTargetCnt = otherPlr->groupCnt;
-    }
-
-    resplen = sizeof(sP_FE2CL_NANO_SKILL_USE_SUCC) + pkt->iTargetCnt * sizeof(sPAYLOAD);
+        resplen = sizeof(sP_FE2CL_NANO_SKILL_USE_SUCC) + pkt->iTargetCnt * sizeof(sPAYLOAD);
+    } else
+        resplen = sizeof(sP_FE2CL_NANO_SKILL_USE_SUCC) + pkt->iTargetCnt * sizeof(sPAYLOAD);
 
     // validate response packet
     if (!validOutVarPacket(sizeof(sP_FE2CL_NANO_SKILL_USE_SUCC), pkt->iTargetCnt, sizeof(sPAYLOAD))) {

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -66,4 +66,5 @@ namespace NanoManager {
 
     int nanoStyle(int nanoId);
     void revivePlayer(Player* plr);
+    void nanoChangeBuff(CNSocket* sock, Player* plr, int32_t cbFrom, int32_t cbTo);
 }

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -64,4 +64,5 @@ struct Player {
     int32_t iIDGroup;
     int groupCnt;
     int32_t groupIDs[4];
+    int32_t iGroupConditionBitFlag;
 };

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -765,11 +765,9 @@ void PlayerManager::revivePlayer(CNSocket* sock, CNPacketData* data) {
             int nanoID = plr->equippedNanos[i];
 
             // halve nano health if respawning
-            if (reviveData->iRegenType != 5) {
+            if (reviveData->iRegenType != 5)
                 plr->Nanos[nanoID].iStamina = 75; // max is 150, so 75 is half
-                response.PCRegenData.Nanos[i] = plr->Nanos[nanoID];
-            }
-
+            response.PCRegenData.Nanos[i] = plr->Nanos[nanoID];
             if (plr->activeNano == nanoID)
                 activeSlot = i;
         }

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -250,7 +250,7 @@ void TableData::loadPaths(int* nextId) {
             auto sliderPoint = _sliderPoint.value();
             if (sliderPoint["stop"] && sliders % 2 == 0) { // check if this point in the circuit is a stop
                 // spawn a slider
-                BaseNPC* slider = new BaseNPC(sliderPoint["iX"], sliderPoint["iY"], sliderPoint["iZ"], 1, (*nextId)++, NPC_BUS);
+                BaseNPC* slider = new BaseNPC(sliderPoint["iX"], sliderPoint["iY"], sliderPoint["iZ"], INSTANCE_OVERWORLD, 1, (*nextId)++, NPC_BUS);
                 NPCManager::NPCs[slider->appearanceData.iNPC_ID] = slider;
                 NPCManager::updateNPCPosition(slider->appearanceData.iNPC_ID, slider->appearanceData.iX, slider->appearanceData.iY, slider->appearanceData.iZ);
                 // set slider path to a rotation of the circuit

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -29,7 +29,7 @@ void TableData::init() {
 
         for (nlohmann::json::iterator _npc = npcData.begin(); _npc != npcData.end(); _npc++) {
             auto npc = _npc.value();
-            BaseNPC *tmp = new BaseNPC(npc["x"], npc["y"], npc["z"], INSTANCE_OVERWORLD, npc["id"], nextId);
+            BaseNPC *tmp = new BaseNPC(npc["x"], npc["y"], npc["z"], npc["angle"], INSTANCE_OVERWORLD, npc["id"], nextId);
 
             NPCManager::NPCs[nextId] = tmp;
             NPCManager::updateNPCPosition(nextId, npc["x"], npc["y"], npc["z"]);
@@ -181,7 +181,7 @@ void TableData::init() {
         for (nlohmann::json::iterator _npc = npcData.begin(); _npc != npcData.end(); _npc++) {
             auto npc = _npc.value();
             auto td = NPCManager::NPCData[(int)npc["iNPCType"]];
-            Mob *tmp = new Mob(npc["iX"], npc["iY"], npc["iZ"], INSTANCE_OVERWORLD, npc["iNPCType"], npc["iHP"], npc["iAngle"], td, nextId);
+            Mob *tmp = new Mob(npc["iX"], npc["iY"], npc["iZ"], npc["iAngle"], INSTANCE_OVERWORLD, npc["iNPCType"], npc["iHP"], td, nextId);
 
             NPCManager::NPCs[nextId] = tmp;
             MobManager::Mobs[nextId] = (Mob*)NPCManager::NPCs[nextId];
@@ -250,7 +250,7 @@ void TableData::loadPaths(int* nextId) {
             auto sliderPoint = _sliderPoint.value();
             if (sliderPoint["stop"] && sliders % 2 == 0) { // check if this point in the circuit is a stop
                 // spawn a slider
-                BaseNPC* slider = new BaseNPC(sliderPoint["iX"], sliderPoint["iY"], sliderPoint["iZ"], INSTANCE_OVERWORLD, 1, (*nextId)++, NPC_BUS);
+                BaseNPC* slider = new BaseNPC(sliderPoint["iX"], sliderPoint["iY"], sliderPoint["iZ"], 0, INSTANCE_OVERWORLD, 1, (*nextId)++, NPC_BUS);
                 NPCManager::NPCs[slider->appearanceData.iNPC_ID] = slider;
                 NPCManager::updateNPCPosition(slider->appearanceData.iNPC_ID, slider->appearanceData.iX, slider->appearanceData.iY, slider->appearanceData.iZ);
                 // set slider path to a rotation of the circuit

--- a/src/TableData.hpp
+++ b/src/TableData.hpp
@@ -16,6 +16,7 @@ namespace TableData {
 
     int getItemType(int);
     void loadPaths(int*);
+    void loadDrops();
     void constructPathSkyway(nlohmann::json::iterator);
     void constructPathSlider(nlohmann::json, int, int);
     void constructPathNPC(nlohmann::json::iterator, int id=0);

--- a/src/TableData.hpp
+++ b/src/TableData.hpp
@@ -18,5 +18,5 @@ namespace TableData {
     void loadPaths(int*);
     void constructPathSkyway(nlohmann::json::iterator);
     void constructPathSlider(nlohmann::json, int, int);
-    void constructPathNPC(nlohmann::json::iterator);
+    void constructPathNPC(nlohmann::json::iterator, int id=0);
 }

--- a/src/TransportManager.cpp
+++ b/src/TransportManager.cpp
@@ -4,6 +4,7 @@
 #include "NanoManager.hpp"
 #include "TransportManager.hpp"
 #include "TableData.hpp"
+#include "MobManager.hpp"
 
 #include <unordered_map>
 #include <cmath>
@@ -275,9 +276,15 @@ void TransportManager::stepNPCPathing() {
         if (NPCManager::NPCs.find(it->first) != NPCManager::NPCs.end())
             npc = NPCManager::NPCs[it->first];
 
-        if (npc == nullptr) {
+        if (npc == nullptr || queue->empty()) {
             // pluck out dead path + update iterator
             it = NPCQueues.erase(it);
+            continue;
+        }
+
+        // do not roam if not roaming
+        if (npc->npcClass == NPC_MOB && ((Mob*)npc)->state != MobState::ROAMING) {
+            it++;
             continue;
         }
 
@@ -291,10 +298,6 @@ void TransportManager::stepNPCPathing() {
         // update NPC location to update viewables
         NPCManager::updateNPCPosition(npc->appearanceData.iNPC_ID, point.x, point.y, point.z);
 
-        // get chunks in view
-        auto chunk = ChunkManager::grabChunk(npc->appearanceData.iX, npc->appearanceData.iY, npc->instanceID);
-        auto chunks = ChunkManager::grabChunks(chunk);
-
         switch (npc->npcClass) {
         case NPC_BUS:
             INITSTRUCT(sP_FE2CL_TRANSPORTATION_MOVE, busMove);
@@ -306,13 +309,11 @@ void TransportManager::stepNPCPathing() {
             busMove.iToZ = point.z;
             busMove.iSpeed = distanceBetween; // set to distance to match how monkeys work
 
-            // send packet to players in view
-            for (Chunk* chunk : chunks) {
-                for (CNSocket* s : chunk->players) {
-                    s->sendPacket(&busMove, P_FE2CL_TRANSPORTATION_MOVE, sizeof(sP_FE2CL_TRANSPORTATION_MOVE));
-                }
-            }
+            NPCManager::sendToViewable(npc, &busMove, P_FE2CL_TRANSPORTATION_MOVE, sizeof(sP_FE2CL_TRANSPORTATION_MOVE));
             break;
+        case NPC_MOB:
+            MobManager::incNextMovement((Mob*)npc);
+            /* fallthrough */
         default:
             INITSTRUCT(sP_FE2CL_NPC_MOVE, move);
             move.iNPC_ID = npc->appearanceData.iNPC_ID;
@@ -322,16 +323,17 @@ void TransportManager::stepNPCPathing() {
             move.iToZ = point.z;
             move.iSpeed = distanceBetween;
 
-            // send packet to players in view
-            for (Chunk* chunk : chunks) {
-                for (CNSocket* s : chunk->players) {
-                    s->sendPacket(&move, P_FE2CL_NPC_MOVE, sizeof(sP_FE2CL_NPC_MOVE));
-                }
-            }
+            NPCManager::sendToViewable(npc, &move, P_FE2CL_NPC_MOVE, sizeof(sP_FE2CL_NPC_MOVE));
             break;
         }
 
-        queue->push(point); // move processed point to the back to maintain cycle
+        /*
+         * Move processed point to the back to maintain cycle, unless this is a
+         * dynamically calculated mob route.
+         */
+        if (!(npc->npcClass == NPC_MOB && !((Mob*)npc)->staticPath))
+            queue->push(point);
+
         it++; // go to next entry in map
     }
 }

--- a/src/TransportManager.cpp
+++ b/src/TransportManager.cpp
@@ -282,6 +282,12 @@ void TransportManager::stepNPCPathing() {
             continue;
         }
 
+        // skip if not simulating mobs
+        if (npc->npcClass == NPC_MOB && !MobManager::simulateMobs) {
+            it++;
+            continue;
+        }
+
         // do not roam if not roaming
         if (npc->npcClass == NPC_MOB && ((Mob*)npc)->state != MobState::ROAMING) {
             it++;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,6 @@ void startShard(CNShardServer* server) {
     server->start();
 }
 
-#ifndef _WIN32
 // terminate gracefully on SIGINT (for gprof)
 void terminate(int arg) {
     std::cout << "OpenFusion: terminating." << std::endl;
@@ -54,6 +53,7 @@ void terminate(int arg) {
     exit(0);
 }
 
+#ifndef _WIN32
 void initsignals() {
     struct sigaction act;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,8 +101,14 @@ int main() {
     TransportManager::init();
     // BuddyManager::init(); // stubbed until we have database integration + lots of bug fixes
     GroupManager::init();
-
     Database::open();
+
+    switch (settings::EVENTMODE)
+    {
+    case 1: std::cout << "[INFO] Event active. Hey, Hey It's Knishmas!" << std::endl; break;
+    case 2: std::cout << "[INFO] Event active. Wishing you a spook-tacular Halloween!" << std::endl; break;
+    case 3: std::cout << "[INFO] Event active. Have a very hoppy Easter!" << std::endl; break;
+    }
 
     std::cout << "[INFO] Starting Server Threads..." << std::endl;
     CNLoginServer loginServer(settings::LOGINPORT);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -12,7 +12,7 @@ int settings::DBSAVEINTERVAL = 240;
 int settings::SHARDPORT = 8002;
 std::string settings::SHARDSERVERIP = "127.0.0.1";
 time_t settings::TIMEOUT = 60000;
-int settings::CHUNKSIZE = 40000;
+int settings::VIEWDISTANCE = 40000;
 bool settings::SIMULATEMOBS = true;
 
 // default spawn point is Sector V (future)
@@ -47,7 +47,7 @@ void settings::init() {
     SHARDSERVERIP = reader.Get("shard", "ip", "127.0.0.1");
     DBSAVEINTERVAL = reader.GetInteger("shard", "dbsaveinterval", DBSAVEINTERVAL);
     TIMEOUT = reader.GetInteger("shard", "timeout", TIMEOUT);
-    CHUNKSIZE = reader.GetInteger("shard", "chunksize", CHUNKSIZE);
+    VIEWDISTANCE = reader.GetInteger("shard", "viewdistance", VIEWDISTANCE);
     SIMULATEMOBS = reader.GetBoolean("shard", "simulatemobs", SIMULATEMOBS);
     SPAWN_X = reader.GetInteger("shard", "spawnx", SPAWN_X);
     SPAWN_Y = reader.GetInteger("shard", "spawny", SPAWN_Y);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -24,9 +24,14 @@ std::string settings::NPCJSON = "tdata/NPCs.json";
 std::string settings::XDTJSON = "tdata/xdt.json";
 std::string settings::MOBJSON = "tdata/mobs.json";
 std::string settings::PATHJSON = "tdata/paths.json";
+std::string settings::DROPSJSON = "tdata/drops.json";
 std::string settings::GRUNTWORKJSON = "tdata/gruntwork.json";
 std::string settings::MOTDSTRING = "Welcome to OpenFusion!";
 int settings::ACCLEVEL = 1;
+
+// event mode settings
+int settings::EVENTMODE = 0;
+int settings::EVENTCRATECHANCE = 10;
 
 void settings::init() {
     INIReader reader("config.ini");
@@ -56,8 +61,11 @@ void settings::init() {
     NPCJSON = reader.Get("shard", "npcdata", NPCJSON);
     XDTJSON = reader.Get("shard", "xdtdata", XDTJSON);
     MOBJSON = reader.Get("shard", "mobdata", MOBJSON);
+    DROPSJSON = reader.Get("shard", "dropdata", DROPSJSON);
     PATHJSON = reader.Get("shard", "pathdata", PATHJSON);
     GRUNTWORKJSON = reader.Get("shard", "gruntwork", GRUNTWORKJSON);
     MOTDSTRING = reader.Get("shard", "motd", MOTDSTRING);
     ACCLEVEL = reader.GetInteger("shard", "accountlevel", ACCLEVEL);
+    EVENTMODE = reader.GetInteger("shard", "eventmode", EVENTMODE);
+    EVENTCRATECHANCE = reader.GetInteger("shard", "eventcratechance", EVENTCRATECHANCE);
 }

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -20,7 +20,10 @@ namespace settings {
     extern std::string XDTJSON;
     extern std::string MOBJSON;
     extern std::string PATHJSON;
+    extern std::string DROPSJSON;
     extern std::string GRUNTWORKJSON;
+    extern int EVENTMODE;
+    extern int EVENTCRATECHANCE;
 
     void init();
 }

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -8,7 +8,7 @@ namespace settings {
     extern int SHARDPORT;
     extern std::string SHARDSERVERIP;
     extern time_t TIMEOUT;
-    extern int CHUNKSIZE;
+    extern int VIEWDISTANCE;
     extern bool SIMULATEMOBS;
     extern int SPAWN_X;
     extern int SPAWN_Y;


### PR DESCRIPTION
- FM, Taros and Boosts awards from killing mobs should be pretty accurate now. A temporary formula for adjusting player/mob level gap is implemented, but it will probably need to be adjusted in the future

- Mobs now drop correct crates

- Crates can be opened and give you correct items
This includes regular mob crates, world boss crates, mission crates, IZ race crates, E.G.G.E.R.s, golden Eggs, and Event Crates.
Keep in mind that neither IZ races or golden Eggs are implemented, but if you spawn such a crate it can be opened.

- All data is read from a json file, for which I'm going to release a tool soon so it's easily adjustable

- There is a new setting for enabling events, which enables dropping extra event crates
These are Knishmas, Halloween and Easter