### PR TITLE
Group warping, Mob movement smoothening, Drain power and Timed debuffs

### DIFF
--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -219,8 +219,15 @@ int MobManager::hitMob(CNSocket *sock, Mob *mob, int damage) {
         mob->appearanceData.iHP -= damage;
 
         // wake up sleeping monster
-        // TODO: remove client-side bit somehow
-        mob->appearanceData.iConditionBitFlag &= ~CSB_BIT_MEZ;
+        if (mob->appearanceData.iConditionBitFlag & CSB_BIT_MEZ) {
+            mob->appearanceData.iConditionBitFlag &= ~CSB_BIT_MEZ;
+
+            INITSTRUCT(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT, pkt1);
+            pkt1.eCT = 2;
+            pkt1.iID = mob->appearanceData.iNPC_ID;
+            pkt1.iConditionBitFlag = mob->appearanceData.iConditionBitFlag;
+            NPCManager::sendToViewable(mob, &pkt1, P_FE2CL_CHAR_TIME_BUFF_TIME_OUT, sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT));
+        }
 
         if (mob->appearanceData.iHP <= 0)
             killMob(mob->target, mob);
@@ -392,10 +399,8 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
 
         pkt.iNPC_ID = mob->appearanceData.iNPC_ID;
         pkt.iSpeed = speed;
-        pkt.iToX = (targ.first - mob->appearanceData.iX) * 5 / 2 + mob->appearanceData.iX;
-        pkt.iToY = (targ.second - mob->appearanceData.iY) * 5 / 2 + mob->appearanceData.iY;
-        mob->appearanceData.iX = targ.first;
-        mob->appearanceData.iY = targ.second;
+        pkt.iToX = mob->appearanceData.iX = targ.first;
+        pkt.iToY = mob->appearanceData.iY = targ.second;
         pkt.iToZ = mob->target->plr->z;
 
         // notify all nearby players
@@ -496,10 +501,8 @@ void MobManager::retreatStep(Mob *mob, time_t currTime) {
         pkt.iSpeed = (int)mob->data["m_iRunSpeed"] * 2;
         mob->appearanceData.iX = targ.first;
         mob->appearanceData.iY = targ.second;
-        pkt.iToX = (targ.first - mob->appearanceData.iX) * 5 / 2 + mob->appearanceData.iX;
-        pkt.iToY = (targ.second - mob->appearanceData.iY) * 5 / 2 + mob->appearanceData.iY;
-        mob->appearanceData.iX = targ.first;
-        mob->appearanceData.iY = targ.second;
+        pkt.iToX = mob->appearanceData.iX = targ.first;
+        pkt.iToY = mob->appearanceData.iY = targ.second;
         pkt.iToZ = mob->appearanceData.iZ;
 
         // notify all nearby players
@@ -527,6 +530,27 @@ void MobManager::step(CNServer *serv, time_t currTime) {
         // skip chunks without players
         if (!ChunkManager::inPopulatedChunks(x, y, pair.second->instanceID))
             continue;
+
+        // drain
+        if (pair.second->appearanceData.iConditionBitFlag & CSB_BIT_BOUNDINGBALL) {
+            pair.second->appearanceData.iHP -= pair.second->maxHealth / 50; // lose 10% every second
+            // TODO: Make this send a damage packet
+        }
+
+        // unbuffing
+        for (auto& pair2 : pair.second->unbuffTimes) {
+            if (currTime >= pair2.second) {
+                pair.second->appearanceData.iConditionBitFlag &= ~pair2.first;
+                
+                INITSTRUCT(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT, pkt1);
+                pkt1.eCT = 2;
+                pkt1.iID = pair.second->appearanceData.iNPC_ID;
+                pkt1.iConditionBitFlag = pair.second->appearanceData.iConditionBitFlag;
+                NPCManager::sendToViewable(pair.second, &pkt1, P_FE2CL_CHAR_TIME_BUFF_TIME_OUT, sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT));
+                
+                pair.second->unbuffTimes.erase(pair2.first);
+            }
+        }
 
         // skip mob movement and combat if disabled
         if (!simulateMobs && pair.second->state != MobState::DEAD

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -82,10 +82,12 @@ void MobManager::pcAttackNpcs(CNSocket *sock, CNPacketData *data) {
         
         int difficulty = (int)mob->data["m_iNpcLevel"];
         
-        damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW >= 11 + difficulty), NanoManager::nanoStyle(plr->activeNano), (int)mob->data["m_iNpcStyle"], difficulty);
+        damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW > 0), NanoManager::nanoStyle(plr->activeNano), (int)mob->data["m_iNpcStyle"], difficulty);
         
-        if (plr->batteryW >= 11 + difficulty)
-            plr->batteryW -= 11 + difficulty;
+        if (plr->batteryW >= 4 + difficulty)
+            plr->batteryW -= 4 + difficulty;
+        else
+            plr->batteryW = 0;
 
         damage.first = hitMob(sock, mob, damage.first);
 
@@ -122,7 +124,7 @@ void MobManager::npcAttackPc(Mob *mob, time_t currTime) {
     sP_FE2CL_NPC_ATTACK_PCs *pkt = (sP_FE2CL_NPC_ATTACK_PCs*)respbuf;
     sAttackResult *atk = (sAttackResult*)(respbuf + sizeof(sP_FE2CL_NPC_ATTACK_PCs));
 
-    auto damage = getDamage(475 + (int)mob->data["m_iPower"], plr->defense, false, false, -1, -1, 1);
+    auto damage = getDamage(450 + (int)mob->data["m_iPower"], plr->defense, false, false, -1, -1, 1);
     plr->HP -= damage.first;
 
     pkt->iNPC_ID = mob->appearanceData.iNPC_ID;
@@ -381,7 +383,7 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
         // movement logic
         if (mob->nextMovement != 0 && currTime < mob->nextMovement)
             return;
-        mob->nextMovement = currTime + 399;
+        mob->nextMovement = currTime + 400;
         if (currTime >= mob->nextAttack)
             mob->nextAttack = 0;
 
@@ -487,7 +489,7 @@ void MobManager::retreatStep(Mob *mob, time_t currTime) {
     if (mob->nextMovement != 0 && currTime < mob->nextMovement)
         return;
 
-    mob->nextMovement = currTime + 399;
+    mob->nextMovement = currTime + 400;
 
     int distance = hypot(mob->appearanceData.iX - mob->roamX, mob->appearanceData.iY - mob->roamY);
 
@@ -517,12 +519,15 @@ void MobManager::retreatStep(Mob *mob, time_t currTime) {
         mob->killedTime = 0;
         mob->nextAttack = 0;
         mob->appearanceData.iConditionBitFlag = 0;
-
-        resendMobHP(mob);
+        
+        // HACK: we haven't found a better way to refresh a mob's client-side status
+        drainMobHP(mob, 0);
     }
 }
 
 void MobManager::step(CNServer *serv, time_t currTime) {
+    static time_t lastDrainTime = 0;
+    
     for (auto& pair : Mobs) {
         int x = pair.second->appearanceData.iX;
         int y = pair.second->appearanceData.iY;
@@ -532,9 +537,8 @@ void MobManager::step(CNServer *serv, time_t currTime) {
             continue;
 
         // drain
-        if (pair.second->appearanceData.iConditionBitFlag & CSB_BIT_BOUNDINGBALL) {
-            pair.second->appearanceData.iHP -= pair.second->maxHealth / 50; // lose 10% every second
-            // TODO: Make this send a damage packet
+        if (currTime - lastDrainTime >= 600 && pair.second->appearanceData.iConditionBitFlag & CSB_BIT_BOUNDINGBALL) {
+            drainMobHP(pair.second, pair.second->maxHealth * 3 / 50); // lose 10% every second
         }
 
         // unbuffing
@@ -580,6 +584,9 @@ void MobManager::step(CNServer *serv, time_t currTime) {
             break;
         }
     }
+    
+    if (currTime - lastDrainTime >= 600)
+        lastDrainTime = currTime;
 
     // deallocate all NPCs queued for removal
     while (RemovalQueue.size() > 0) {
@@ -640,8 +647,10 @@ void MobManager::combatBegin(CNSocket *sock, CNPacketData *data) {
 void MobManager::combatEnd(CNSocket *sock, CNPacketData *data) {
     Player *plr = PlayerManager::getPlayer(sock);
 
-    if (plr != nullptr)
+    if (plr != nullptr) {
         plr->inCombat = false;
+        plr->healCooldown = 4000;
+    }
 }
 
 void MobManager::dotDamageOnOff(CNSocket *sock, CNPacketData *data) {
@@ -736,16 +745,19 @@ void MobManager::playerTick(CNServer *serv, time_t currTime) {
             dealGooDamage(sock, PC_MAXHEALTH(plr->level) * 3 / 20);
 
         // heal
-        if (currTime - lastHealTime >= 6000 && !plr->inCombat && plr->HP < PC_MAXHEALTH(plr->level)) {
-            plr->HP += PC_MAXHEALTH(plr->level) / 5;
-            if (plr->HP > PC_MAXHEALTH(plr->level))
-                plr->HP = PC_MAXHEALTH(plr->level);
-            transmit = true;
+        if (currTime - lastHealTime >= 4000 && !plr->inCombat && plr->HP < PC_MAXHEALTH(plr->level)) {
+            if (currTime - lastHealTime - plr->healCooldown >= 4000) {
+                plr->HP += PC_MAXHEALTH(plr->level) / 5;
+                if (plr->HP > PC_MAXHEALTH(plr->level))
+                    plr->HP = PC_MAXHEALTH(plr->level);
+                transmit = true;
+            } else
+                plr->healCooldown -= 4000;
         }
 
         for (int i = 0; i < 3; i++) {
             if (plr->activeNano != 0 && plr->equippedNanos[i] == plr->activeNano) { // spend stamina
-                plr->Nanos[plr->activeNano].iStamina -= 1;
+                plr->Nanos[plr->activeNano].iStamina -= 2;
 
                 if (plr->passiveNanoOut)
                    plr->Nanos[plr->activeNano].iStamina -= 1;
@@ -782,7 +794,7 @@ void MobManager::playerTick(CNServer *serv, time_t currTime) {
     }
 
     // if this was a heal tick, update the counter outside of the loop
-    if (currTime - lastHealTime >= 6000)
+    if (currTime - lastHealTime >= 4000)
         lastHealTime = currTime;
 }
 
@@ -795,15 +807,15 @@ std::pair<int,int> MobManager::getDamage(int attackPower, int defensePower, bool
 
     // base calculation
     int damage = attackPower * attackPower / (attackPower + defensePower);
-    damage = std::max(std::max(29, attackPower / 7), damage - defensePower * (12 + difficulty) / 65);
+    damage = std::max(10 + attackPower / 10, damage - defensePower * (4 + difficulty) / 40);
     damage = damage * (rand() % 40 + 80) / 100;
     
     // Adaptium/Blastons/Cosmix
     if (attackerStyle != -1 && defenderStyle != -1 && attackerStyle != defenderStyle) {
         if (attackerStyle < defenderStyle || attackerStyle - defenderStyle == 2) 
-            damage = damage * 5 / 4;
+            damage = damage * 3 / 2;
         else
-            damage = damage * 4 / 5;
+            damage = damage * 2 / 3;
     }
     
     // weapon boosts
@@ -875,11 +887,13 @@ void MobManager::pcAttackChars(CNSocket *sock, CNPacketData *data) {
                 damage.first = plr->groupDamage;
             else
                 damage.first = plr->pointDamage;
-        
-            damage = getDamage(damage.first, target->defense, true, (plr->batteryW >= 12), -1, -1, 1);
-        
-            if (plr->batteryW >= 12)
-                plr->batteryW -= 12;
+ 
+            damage = getDamage(damage.first, target->defense, true, (plr->batteryW > 0), -1, -1, 1);
+
+            if (plr->batteryW >= 4 + plr->level)
+                plr->batteryW -= 4 + plr->level;
+            else
+                plr->batteryW = 0;
 
             target->HP -= damage.first;
 
@@ -902,14 +916,16 @@ void MobManager::pcAttackChars(CNSocket *sock, CNPacketData *data) {
                 damage.first = plr->groupDamage;
             else
                 damage.first = plr->pointDamage;
-            
+
             int difficulty = (int)mob->data["m_iNpcLevel"];
-            
-            damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW >= 11 + difficulty),
+
+            damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW > 0),
                 NanoManager::nanoStyle(plr->activeNano), (int)mob->data["m_iNpcStyle"], difficulty);
-            
-            if (plr->batteryW >= 11 + difficulty)
-                plr->batteryW -= 11 + difficulty;
+
+            if (plr->batteryW >= 4 + difficulty)
+                plr->batteryW -= 4 + difficulty;
+            else
+                plr->batteryW = 0;
 
             damage.first = hitMob(sock, mob, damage.first);
 
@@ -933,25 +949,24 @@ void MobManager::pcAttackChars(CNSocket *sock, CNPacketData *data) {
     PlayerManager::sendToViewable(sock, (void*)respbuf, P_FE2CL_PC_ATTACK_CHARs, resplen);
 }
 
-// HACK: we haven't found a better way to refresh a mob's client-side status
-void MobManager::resendMobHP(Mob *mob) {
-    size_t resplen = sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK) + sizeof(sSkillResult_Heal_HP);
+void MobManager::drainMobHP(Mob *mob, int amount) {
+    size_t resplen = sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK) + sizeof(sSkillResult_Damage);
     assert(resplen < CN_PACKET_BUFFER_SIZE - 8);
     uint8_t respbuf[CN_PACKET_BUFFER_SIZE];
 
     memset(respbuf, 0, resplen);
 
     sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK *pkt = (sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK*)respbuf;
-    sSkillResult_Heal_HP *heal = (sSkillResult_Heal_HP*)(respbuf + sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK));
+    sSkillResult_Damage *drain = (sSkillResult_Damage*)(respbuf + sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK));
 
     pkt->iID = mob->appearanceData.iNPC_ID;
     pkt->eCT = 4; // mob
-    pkt->iTB_ID = ECSB_HEAL; // sSkillResult_Heal_HP
+    pkt->iTB_ID = ECSB_BOUNDINGBALL;
 
-    heal->eCT = 4;
-    heal->iID = mob->appearanceData.iNPC_ID;
-    heal->iHealHP = 0;
-    heal->iHP = mob->appearanceData.iHP;
+    drain->eCT = 4;
+    drain->iID = mob->appearanceData.iNPC_ID;
+    drain->iDamage = amount;
+    drain->iHP = mob->appearanceData.iHP -= amount;
 
     NPCManager::sendToViewable(mob, (void*)&respbuf, P_FE2CL_CHAR_TIME_BUFF_TIME_TICK, resplen);
 }

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -115,7 +115,7 @@ namespace MobManager {
     std::pair<int,int> getDamage(int, int, bool, bool, int, int, int);
 
     void pcAttackChars(CNSocket *sock, CNPacketData *data);
-    void resendMobHP(Mob *mob);
+    void drainMobHP(Mob *mob, int amount);
     void incNextMovement(Mob *mob, time_t currTime=0);
     bool aggroCheck(Mob *mob, time_t currTime);
 }

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -8,6 +8,7 @@
 #include "contrib/JSON.hpp"
 
 #include <map>
+#include <unordered_map>
 #include <queue>
 
 enum class MobState {
@@ -25,6 +26,7 @@ struct Mob : public BaseNPC {
     int spawnX;
     int spawnY;
     int spawnZ;
+    std::unordered_map<int32_t,time_t> unbuffTimes;
 
     // dead
     time_t killedTime = 0;
@@ -36,11 +38,12 @@ struct Mob : public BaseNPC {
     int idleRange;
     time_t nextMovement = 0;
     bool staticPath = false;
+    int roamX, roamY, roamZ;
 
     // combat
     CNSocket *target = nullptr;
     time_t nextAttack = 0;
-    int roamX, roamY, roamZ;
+
 
     // temporary; until we're sure what's what
     nlohmann::json data;

--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -407,14 +407,14 @@ bool doDebuff(CNSocket *sock, int32_t *pktdata, sSkillResult_Damage_N_Debuff *re
 
     Mob* mob = MobManager::Mobs[pktdata[i]];
 
-    int damage = MobManager::hitMob(sock, mob, amount);
+    int damage = MobManager::hitMob(sock, mob, 0); // using amount for something else
 
     respdata[i].eCT = 4;
     respdata[i].iDamage = damage;
     respdata[i].iID = mob->appearanceData.iNPC_ID;
     respdata[i].iHP = mob->appearanceData.iHP;
     respdata[i].iConditionBitFlag = mob->appearanceData.iConditionBitFlag |= iCBFlag;
-
+    mob->unbuffTimes[iCBFlag] = getTime() + amount;
     std::cout << (int)mob->appearanceData.iNPC_ID << " was debuffed" << std::endl;
 
     return true;
@@ -428,10 +428,12 @@ bool doBuff(CNSocket *sock, int32_t *pktdata, sSkillResult_Buff *respdata, int i
     }
 
     Mob* mob = MobManager::Mobs[pktdata[i]];
+    MobManager::hitMob(sock, mob, 0);
 
     respdata[i].eCT = 4;
     respdata[i].iID = mob->appearanceData.iNPC_ID;
     respdata[i].iConditionBitFlag = mob->appearanceData.iConditionBitFlag |= iCBFlag;
+    mob->unbuffTimes[iCBFlag] = getTime() + amount;
 
     std::cout << (int)mob->appearanceData.iNPC_ID << " was debuffed" << std::endl;
 
@@ -669,15 +671,15 @@ void activePower(CNSocket *sock, CNPacketData *data,
 
 // active nano power dispatch table
 std::vector<ActivePower> ActivePowers = {
-    ActivePower(StunPowers, activePower<sSkillResult_Damage_N_Debuff,  doDebuff>,         EST_STUN, CSB_BIT_STUN,                 0),
+    ActivePower(StunPowers, activePower<sSkillResult_Damage_N_Debuff,  doDebuff>,         EST_STUN, CSB_BIT_STUN,              2250),
     ActivePower(HealPowers, activePower<sSkillResult_Heal_HP,          doHeal>,           EST_HEAL_HP, CSB_BIT_NONE,             25),
-    ActivePower(GroupHealPowers, activePower<sSkillResult_Heal_HP,     doGroupHeal, GHEAL>,EST_HEAL_HP, CSB_BIT_NONE,            25),
+    ActivePower(GroupHealPowers, activePower<sSkillResult_Heal_HP,     doGroupHeal, GHEAL>,EST_HEAL_HP, CSB_BIT_NONE,            15),
     // TODO: Recall
-    ActivePower(DrainPowers, activePower<sSkillResult_Buff,            doBuff>,           EST_BOUNDINGBALL, CSB_BIT_BOUNDINGBALL, 0),
-    ActivePower(SnarePowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SNARE, CSB_BIT_DN_MOVE_SPEED,       0),
+    ActivePower(DrainPowers, activePower<sSkillResult_Buff,            doBuff>,        EST_BOUNDINGBALL, CSB_BIT_BOUNDINGBALL, 3000),
+    ActivePower(SnarePowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SNARE, CSB_BIT_DN_MOVE_SPEED,    4500),
     ActivePower(DamagePowers, activePower<sSkillResult_Damage,         doDamage>,         EST_DAMAGE, CSB_BIT_NONE,              12),
     ActivePower(LeechPowers, activePower<sSkillResult_Heal_HP,         doLeech, LEECH>,   EST_BLOODSUCKING, CSB_BIT_NONE,        18),
-    ActivePower(SleepPowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SLEEP, CSB_BIT_MEZ,                 0),
+    ActivePower(SleepPowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SLEEP, CSB_BIT_MEZ,              4500),
 };
 
 }; // namespace

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -50,6 +50,7 @@ struct Player {
 
     bool inCombat;
     bool passiveNanoOut;
+    int healCooldown;
 
     int pointDamage;
     int groupDamage;

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -249,6 +249,7 @@ void PlayerManager::sendPlayerTo(CNSocket* sock, int X, int Y, int Z, uint64_t I
         PlayerManager::removePlayerFromChunks(plrv.currentChunks, sock);
         plrv.currentChunks.clear();
         sock->sendPacket((void*)&resp, P_FE2CL_REP_PC_WARP_USE_NPC_SUCC, sizeof(sP_FE2CL_REP_PC_WARP_USE_NPC_SUCC));
+        updatePlayerPosition(sock, X, Y, Z);
     }
     
 }
@@ -266,6 +267,7 @@ void PlayerManager::sendPlayerTo(CNSocket* sock, int X, int Y, int Z) {
     plrv.currentChunks.clear();
     plrv.chunkPos = std::make_tuple(0, 0, plrv.plr->instanceID);
     sock->sendPacket((void*)&pkt, P_FE2CL_REP_PC_GOTO_SUCC, sizeof(sP_FE2CL_REP_PC_GOTO_SUCC));
+    updatePlayerPosition(sock, X, Y, Z);
 }
 
 void PlayerManager::enterPlayer(CNSocket* sock, CNPacketData* data) {


### PR DESCRIPTION
Main Changes:
* Warping into IZs and Fusion Lairs now will also take into account your group members.
* Mobs pursue their targets more smoothly, they will avoid phasing into the player during combat.
* Nerfed retreat speed by a factor of 1.5, normal mobs retreated way too quickly however mobs like Don Doom and Bad Max do not retreat fast enough.
* Bugfixed sendPlayerTo, it did not call updatePlayerPosition leaving undesirable anomalies.
* Nano drain power works, currently does 30% damage over a period of 3 seconds.
* Stun, Sleep and Snare powers will now run out of time on mobs.
* Weapons will consume your batteries fully.
* Nerfed enemy damage at lower levels.
* Players heal faster after a sizable cooldown.
* Nano type advantage is more noticeable during combat.
* Added /minfo, returns your current active mission's: id, task id, task type and enemy ids if applicable. (Perms level 30)
* Added /tasks, returns all the active mission ids and task ids. (Perms level 30)

Codebase changes:
* MobManager lerp does not confusingly divide speed by 2 anymore.
* resendMobHP() has been repurposed to drainMobHP(), drain uses a static variable as a timer (lastDrainTime).