### PR TITLE
Group Warping, Mob Smoothening and Various Bugfixes

### DIFF
--- a/src/ChatManager.cpp
+++ b/src/ChatManager.cpp
@@ -411,6 +411,7 @@ void minfoCommand(std::string full, std::vector<std::string>& args, CNSocket* so
                 ChatManager::sendServerMessage(sock, "[MINFO] Current task ID: " + std::to_string(plr->tasks[i]));
                 ChatManager::sendServerMessage(sock, "[MINFO] Current task type: " + std::to_string((int)(task["m_iHTaskType"])));
                 ChatManager::sendServerMessage(sock, "[MINFO] Current waypoint NPC ID: " + std::to_string((int)(task["m_iSTGrantWayPoint"])));
+                ChatManager::sendServerMessage(sock, "[MINFO] Current terminator NPC ID: " + std::to_string((int)(task["m_iHTerminatorNPCID"])));
 
                 for (int j = 0; j < 3; j++)
                     if ((int)(task["m_iCSUEnemyID"][j]) != 0)

--- a/src/GroupManager.cpp
+++ b/src/GroupManager.cpp
@@ -29,12 +29,12 @@ void GroupManager::requestGroup(CNSocket* sock, CNPacketData* data) {
     Player* otherPlr = PlayerManager::getPlayerFromID(recv->iID_To);
 
     if (plr == nullptr || otherPlr == nullptr)
-		return;
+        return;
 
     otherPlr = PlayerManager::getPlayerFromID(otherPlr->iIDGroup);
 
     if (otherPlr == nullptr)
-		return;
+        return;
 
     // fail if the group is full or the other player is already in a group
     if (plr->groupCnt >= 4 || otherPlr->groupCnt > 1) {
@@ -50,9 +50,9 @@ void GroupManager::requestGroup(CNSocket* sock, CNPacketData* data) {
 
     INITSTRUCT(sP_FE2CL_PC_GROUP_INVITE, resp);
 
-	resp.iHostID = plr->iIDGroup;
+    resp.iHostID = plr->iIDGroup;
 
-	otherSock->sendPacket((void*)&resp, P_FE2CL_PC_GROUP_INVITE, sizeof(sP_FE2CL_PC_GROUP_INVITE));
+    otherSock->sendPacket((void*)&resp, P_FE2CL_PC_GROUP_INVITE, sizeof(sP_FE2CL_PC_GROUP_INVITE));
 }
 
 void GroupManager::refuseGroup(CNSocket* sock, CNPacketData* data) {
@@ -61,7 +61,7 @@ void GroupManager::refuseGroup(CNSocket* sock, CNPacketData* data) {
 
     sP_CL2FE_REQ_PC_GROUP_INVITE_REFUSE* recv = (sP_CL2FE_REQ_PC_GROUP_INVITE_REFUSE*)data->buf;
 
-	CNSocket* otherSock = PlayerManager::getSockFromID(recv->iID_From);
+    CNSocket* otherSock = PlayerManager::getSockFromID(recv->iID_From);
 
     if (otherSock == nullptr)
         return;
@@ -69,13 +69,13 @@ void GroupManager::refuseGroup(CNSocket* sock, CNPacketData* data) {
     Player* plr = PlayerManager::getPlayer(sock);
 
     if (plr == nullptr)
-		return;
+        return;
 
     INITSTRUCT(sP_FE2CL_PC_GROUP_INVITE_REFUSE, resp);
 
     resp.iID_To = plr->iID;
 
-	otherSock->sendPacket((void*)&resp, P_FE2CL_PC_GROUP_INVITE_REFUSE, sizeof(sP_FE2CL_PC_GROUP_INVITE_REFUSE));
+    otherSock->sendPacket((void*)&resp, P_FE2CL_PC_GROUP_INVITE_REFUSE, sizeof(sP_FE2CL_PC_GROUP_INVITE_REFUSE));
 }
 
 void GroupManager::joinGroup(CNSocket* sock, CNPacketData* data) {
@@ -87,12 +87,12 @@ void GroupManager::joinGroup(CNSocket* sock, CNPacketData* data) {
     Player* otherPlr = PlayerManager::getPlayerFromID(recv->iID_From);
 
     if (plr == nullptr || otherPlr == nullptr)
-		return;
+        return;
 
     otherPlr = PlayerManager::getPlayerFromID(otherPlr->iIDGroup);
 
     if (otherPlr == nullptr)
-		return;
+        return;
 
     // fail if the group is full or the other player is already in a group
     if (plr->groupCnt > 1 || plr->iIDGroup != plr->iID || otherPlr->groupCnt >= 4) {
@@ -172,7 +172,7 @@ void GroupManager::chatGroup(CNSocket* sock, CNPacketData* data) {
     Player* otherPlr = PlayerManager::getPlayerFromID(plr->iIDGroup);
 
     if (plr == nullptr || otherPlr == nullptr)
-		return;
+        return;
 
     // send to client
     INITSTRUCT(sP_FE2CL_REP_SEND_ALL_GROUP_FREECHAT_MESSAGE_SUCC, resp);
@@ -184,14 +184,14 @@ void GroupManager::chatGroup(CNSocket* sock, CNPacketData* data) {
 
 void GroupManager::menuChatGroup(CNSocket* sock, CNPacketData* data) {
     if (data->size != sizeof(sP_CL2FE_REQ_SEND_ALL_GROUP_MENUCHAT_MESSAGE))
-		return; // malformed packet
+        return; // malformed packet
 
     sP_CL2FE_REQ_SEND_ALL_GROUP_MENUCHAT_MESSAGE* chat = (sP_CL2FE_REQ_SEND_ALL_GROUP_MENUCHAT_MESSAGE*)data->buf;
     Player* plr = PlayerManager::getPlayer(sock);
     Player* otherPlr = PlayerManager::getPlayerFromID(plr->iIDGroup);
 
     if (plr == nullptr || otherPlr == nullptr)
-		return;
+        return;
 
     // send to client
     INITSTRUCT(sP_FE2CL_REP_SEND_ALL_GROUP_MENUCHAT_MESSAGE_SUCC, resp);
@@ -276,7 +276,7 @@ void GroupManager::groupKickPlayer(Player* plr) {
     Player* otherPlr = PlayerManager::getPlayerFromID(plr->iIDGroup);
 
     if (otherPlr == nullptr)
-		return;
+        return;
 
     if (!validOutVarPacket(sizeof(sP_FE2CL_PC_GROUP_LEAVE), otherPlr->groupCnt - 1, sizeof(sPCGroupMemberInfo))) {
         std::cout << "[WARN] bad sP_FE2CL_PC_GROUP_LEAVE packet size\n";
@@ -340,7 +340,7 @@ void GroupManager::groupKickPlayer(Player* plr) {
     CNSocket* sock = PlayerManager::getSockFromID(plr->iID);
 
     if (sock == nullptr)
-		return;
+        return;
 
     INITSTRUCT(sP_FE2CL_PC_GROUP_LEAVE_SUCC, resp1);
     sock->sendPacket((void*)&resp1, P_FE2CL_PC_GROUP_LEAVE_SUCC, sizeof(sP_FE2CL_PC_GROUP_LEAVE_SUCC));

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -140,12 +140,12 @@ void ItemManager::itemMoveHandler(CNSocket* sock, CNPacketData* data) {
         INITSTRUCT(sP_FE2CL_PC_EQUIP_CHANGE, equipChange);
 
         equipChange.iPC_ID = plr.plr->iID;
-        if (itemmove->eFrom == (int)SlotType::EQUIP) {
-            equipChange.iEquipSlotNum = itemmove->iFromSlotNum;
-            equipChange.EquipSlotItem = resp.ToSlotItem;
-        } else {
+        if (itemmove->eTo == (int)SlotType::EQUIP) {
             equipChange.iEquipSlotNum = itemmove->iToSlotNum;
             equipChange.EquipSlotItem = resp.FromSlotItem;
+        } else {
+            equipChange.iEquipSlotNum = itemmove->iFromSlotNum;
+            equipChange.EquipSlotItem = resp.ToSlotItem;
         }
 
         // unequip vehicle if equip slot 8 is 0

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -467,7 +467,15 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
     if (distance <= (int)mob->data["m_iAtkRange"]) {
         // attack logic
         if (mob->nextAttack == 0) {
-            mob->nextAttack = currTime + (int)mob->data["m_iInitalTime"] * 100; // I *think* this is what this is
+            INITSTRUCT(sP_FE2CL_NPC_MOVE, pkt);
+            pkt.iNPC_ID = mob->appearanceData.iNPC_ID;
+            pkt.iSpeed = (int)mob->data["m_iRunSpeed"];
+            pkt.iToX = mob->appearanceData.iX;
+            pkt.iToY = mob->appearanceData.iY;
+            pkt.iToZ = mob->target->plr->z;
+            NPCManager::sendToViewable(mob, &pkt, P_FE2CL_NPC_MOVE, sizeof(sP_FE2CL_NPC_MOVE));
+
+            mob->nextAttack = currTime + (int)mob->data["m_iInitalTime"] * 100; //I *think* this is what this is
             npcAttackPc(mob, currTime);
         } else if (mob->nextAttack != 0 && currTime >= mob->nextAttack) {
             mob->nextAttack = currTime + (int)mob->data["m_iDelayTime"] * 100;
@@ -477,7 +485,9 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
         // movement logic
         if (mob->nextMovement != 0 && currTime < mob->nextMovement)
             return;
-        mob->nextMovement = currTime + 500;
+        mob->nextMovement = currTime + 399;
+        if (currTime >= mob->nextAttack)
+            mob->nextAttack = 0;
 
         int speed = mob->data["m_iRunSpeed"];
 
@@ -485,7 +495,7 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
         if (mob->appearanceData.iConditionBitFlag & CSB_BIT_DN_MOVE_SPEED)
             speed /= 2;
 
-        auto targ = lerp(mob->appearanceData.iX, mob->appearanceData.iY, mob->target->plr->x, mob->target->plr->y, speed);
+        auto targ = lerp(mob->appearanceData.iX, mob->appearanceData.iY, mob->target->plr->x, mob->target->plr->y,std::min(distance-(int)mob->data["m_iAtkRange"]+1, speed*2/5));
 
         NPCManager::updateNPCPosition(mob->appearanceData.iNPC_ID, targ.first, targ.second, mob->appearanceData.iZ);
 
@@ -493,9 +503,11 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
 
         pkt.iNPC_ID = mob->appearanceData.iNPC_ID;
         pkt.iSpeed = speed;
-        pkt.iToX = mob->appearanceData.iX = targ.first;
-        pkt.iToY = mob->appearanceData.iY = targ.second;
-        pkt.iToZ = mob->appearanceData.iZ;
+        pkt.iToX = (targ.first - mob->appearanceData.iX) * 5 / 2 + mob->appearanceData.iX;
+        pkt.iToY = (targ.second - mob->appearanceData.iY) * 5 / 2 + mob->appearanceData.iY;
+        mob->appearanceData.iX = targ.first;
+        mob->appearanceData.iY = targ.second;
+        pkt.iToZ = mob->target->plr->z;
 
         // notify all nearby players
         NPCManager::sendToViewable(mob, &pkt, P_FE2CL_NPC_MOVE, sizeof(sP_FE2CL_NPC_MOVE));
@@ -582,7 +594,7 @@ void MobManager::retreatStep(Mob *mob, time_t currTime) {
     if (mob->nextMovement != 0 && currTime < mob->nextMovement)
         return;
 
-    mob->nextMovement = currTime + 500;
+    mob->nextMovement = currTime + 399;
 
     int distance = hypot(mob->appearanceData.iX - mob->roamX, mob->appearanceData.iY - mob->roamY);
 
@@ -590,12 +602,16 @@ void MobManager::retreatStep(Mob *mob, time_t currTime) {
     if (distance > 10) {
         INITSTRUCT(sP_FE2CL_NPC_MOVE, pkt);
 
-        auto targ = lerp(mob->appearanceData.iX, mob->appearanceData.iY, mob->roamX, mob->roamY, (int)mob->data["m_iRunSpeed"] * 3);
+        auto targ = lerp(mob->appearanceData.iX, mob->appearanceData.iY, mob->roamX, mob->roamY, (int)mob->data["m_iRunSpeed"]*4/5);
 
         pkt.iNPC_ID = mob->appearanceData.iNPC_ID;
-        pkt.iSpeed = (int)mob->data["m_iRunSpeed"] * 3;
-        pkt.iToX = mob->appearanceData.iX = targ.first;
-        pkt.iToY = mob->appearanceData.iY = targ.second;
+        pkt.iSpeed = (int)mob->data["m_iRunSpeed"] * 2;
+        mob->appearanceData.iX = targ.first;
+        mob->appearanceData.iY = targ.second;
+        pkt.iToX = (targ.first - mob->appearanceData.iX) * 5 / 2 + mob->appearanceData.iX;
+        pkt.iToY = (targ.second - mob->appearanceData.iY) * 5 / 2 + mob->appearanceData.iY;
+        mob->appearanceData.iX = targ.first;
+        mob->appearanceData.iY = targ.second;
         pkt.iToZ = mob->appearanceData.iZ;
 
         // notify all nearby players
@@ -666,8 +682,6 @@ void MobManager::step(CNServer *serv, time_t currTime) {
  */
 std::pair<int,int> MobManager::lerp(int x1, int y1, int x2, int y2, int speed) {
     std::pair<int,int> ret = {x1, y1};
-
-    speed /= 2;
 
     if (speed == 0)
         return ret;

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -85,10 +85,10 @@ void MobManager::pcAttackNpcs(CNSocket *sock, CNPacketData *data) {
             damage.first = plr->pointDamage;
 
         int difficulty = (int)mob->data["m_iNpcLevel"];
-        damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW > 0), NanoManager::nanoStyle(plr->activeNano), (int)mob->data["m_iNpcStyle"], difficulty);
+        damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW > 6 + difficulty), NanoManager::nanoStyle(plr->activeNano), (int)mob->data["m_iNpcStyle"], difficulty);
         
-        if (plr->batteryW >= 4 + difficulty)
-            plr->batteryW -= 4 + difficulty;
+        if (plr->batteryW >= 6 + difficulty)
+            plr->batteryW -= 6 + difficulty;
         else
             plr->batteryW = 0;
 
@@ -127,7 +127,7 @@ void MobManager::npcAttackPc(Mob *mob, time_t currTime) {
     sP_FE2CL_NPC_ATTACK_PCs *pkt = (sP_FE2CL_NPC_ATTACK_PCs*)respbuf;
     sAttackResult *atk = (sAttackResult*)(respbuf + sizeof(sP_FE2CL_NPC_ATTACK_PCs));
 
-    auto damage = getDamage(450 + (int)mob->data["m_iPower"], plr->defense, false, false, -1, -1, 1);
+    auto damage = getDamage(450 + (int)mob->data["m_iPower"], plr->defense, false, false, -1, -1, rand() % plr->level + 1);
     plr->HP -= damage.first;
 
     pkt->iNPC_ID = mob->appearanceData.iNPC_ID;
@@ -330,16 +330,16 @@ int MobManager::hitMob(CNSocket *sock, Mob *mob, int damage) {
 
     mob->appearanceData.iHP -= damage;
 
-        // wake up sleeping monster
-        if (mob->appearanceData.iConditionBitFlag & CSB_BIT_MEZ) {
-            mob->appearanceData.iConditionBitFlag &= ~CSB_BIT_MEZ;
+    // wake up sleeping monster
+    if (mob->appearanceData.iConditionBitFlag & CSB_BIT_MEZ) {
+        mob->appearanceData.iConditionBitFlag &= ~CSB_BIT_MEZ;
 
-            INITSTRUCT(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT, pkt1);
-            pkt1.eCT = 2;
-            pkt1.iID = mob->appearanceData.iNPC_ID;
-            pkt1.iConditionBitFlag = mob->appearanceData.iConditionBitFlag;
-            NPCManager::sendToViewable(mob, &pkt1, P_FE2CL_CHAR_TIME_BUFF_TIME_OUT, sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT));
-        }
+        INITSTRUCT(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT, pkt1);
+        pkt1.eCT = 2;
+        pkt1.iID = mob->appearanceData.iNPC_ID;
+        pkt1.iConditionBitFlag = mob->appearanceData.iConditionBitFlag;
+        NPCManager::sendToViewable(mob, &pkt1, P_FE2CL_CHAR_TIME_BUFF_TIME_OUT, sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT));
+    }
 
     if (mob->appearanceData.iHP <= 0)
         killMob(mob->target, mob);
@@ -616,7 +616,7 @@ void MobManager::retreatStep(Mob *mob, time_t currTime) {
         mob->appearanceData.iY = targ.second;
         pkt.iToX = mob->appearanceData.iX = targ.first;
         pkt.iToY = mob->appearanceData.iY = targ.second;
-        pkt.iToZ = mob->appearanceData.iZ;
+        pkt.iToZ = mob->appearanceData.iZ = mob->spawnZ;
 
         // notify all nearby players
         NPCManager::sendToViewable(mob, &pkt, P_FE2CL_NPC_MOVE, sizeof(sP_FE2CL_NPC_MOVE));
@@ -999,10 +999,10 @@ void MobManager::pcAttackChars(CNSocket *sock, CNPacketData *data) {
             else
                 damage.first = plr->pointDamage;
 
-            damage = getDamage(damage.first, target->defense, true, (plr->batteryW > 0), -1, -1, 1);
+            damage = getDamage(damage.first, target->defense, true, (plr->batteryW > 6 + plr->level), -1, -1, 1);
 
-            if (plr->batteryW >= 4 + plr->level)
-                plr->batteryW -= 4 + plr->level;
+            if (plr->batteryW >= 6 + plr->level)
+                plr->batteryW -= 6 + plr->level;
             else
                 plr->batteryW = 0;
 
@@ -1030,11 +1030,11 @@ void MobManager::pcAttackChars(CNSocket *sock, CNPacketData *data) {
 
             int difficulty = (int)mob->data["m_iNpcLevel"];
 
-            damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW > 0),
+            damage = getDamage(damage.first, (int)mob->data["m_iProtection"], true, (plr->batteryW > 6 + difficulty),
                 NanoManager::nanoStyle(plr->activeNano), (int)mob->data["m_iNpcStyle"], difficulty);
 
-            if (plr->batteryW >= 4 + difficulty)
-                plr->batteryW -= 4 + difficulty;
+            if (plr->batteryW >= 6 + difficulty)
+                plr->batteryW -= 6 + difficulty;
             else
                 plr->batteryW = 0;
 

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -139,7 +139,7 @@ namespace MobManager {
     std::pair<int,int> getDamage(int, int, bool, bool, int, int, int);
 
     void pcAttackChars(CNSocket *sock, CNPacketData *data);
-    void resendMobHP(Mob *mob);
+    void drainMobHP(Mob *mob, int amount);
     void incNextMovement(Mob *mob, time_t currTime=0);
     bool aggroCheck(Mob *mob, time_t currTime);
 }

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -8,6 +8,7 @@
 #include "contrib/JSON.hpp"
 
 #include <map>
+#include <unordered_map>
 #include <queue>
 
 enum class MobState {
@@ -27,6 +28,8 @@ struct Mob : public BaseNPC {
     int spawnZ;
     int level;
 
+    std::unordered_map<int32_t,time_t> unbuffTimes;
+
     // dead
     time_t killedTime = 0;
     time_t regenTime;
@@ -38,11 +41,12 @@ struct Mob : public BaseNPC {
     const int sightRange;
     time_t nextMovement = 0;
     bool staticPath = false;
+    int roamX, roamY, roamZ;
 
     // combat
     CNSocket *target = nullptr;
     time_t nextAttack = 0;
-    int roamX, roamY, roamZ;
+
 
     // drop
     int dropType;

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -606,9 +606,32 @@ void NPCManager::handleWarp(CNSocket* sock, int32_t warpId) {
             ChunkManager::createInstance(instanceID);
         }
 
-        PlayerManager::sendPlayerTo(sock, Warps[warpId].x, Warps[warpId].y, Warps[warpId].z, instanceID);
-    } else {
-        INITSTRUCT(sP_FE2CL_REP_PC_WARP_USE_NPC_SUCC, resp); // Can only be used for exiting instances because it sets the instance flag to false
+        if (plrv.plr->iID == plrv.plr->iIDGroup && plrv.plr->groupCnt == 1)
+            PlayerManager::sendPlayerTo(sock, Warps[warpId].x, Warps[warpId].y, Warps[warpId].z, instanceID);
+        else {
+            Player* leaderPlr = PlayerManager::getPlayerFromID(plrv.plr->iIDGroup);
+
+            for (int i = 0; i < leaderPlr->groupCnt; i++) {
+                Player* otherPlr = PlayerManager::getPlayerFromID(leaderPlr->groupIDs[i]);
+                CNSocket* sockTo = PlayerManager::getSockFromID(leaderPlr->groupIDs[i]);
+
+                if (otherPlr == nullptr || sockTo == nullptr)
+                    continue;
+
+                if (otherPlr->instanceID == 0) {
+                    otherPlr->lastX = otherPlr->x;
+                    otherPlr->lastY = otherPlr->y;
+                    otherPlr->lastZ = otherPlr->z;
+                    otherPlr->lastAngle = otherPlr->angle;
+                }
+
+                PlayerManager::sendPlayerTo(sockTo, Warps[warpId].x, Warps[warpId].y, Warps[warpId].z, instanceID);
+            }
+        }
+    }
+    else
+    {
+        INITSTRUCT(sP_FE2CL_REP_PC_WARP_USE_NPC_SUCC, resp); //Can only be used for exiting instances because it sets the instance flag to false
         resp.iX = Warps[warpId].x;
         resp.iY = Warps[warpId].y;
         resp.iZ = Warps[warpId].z;

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -618,13 +618,6 @@ void NPCManager::handleWarp(CNSocket* sock, int32_t warpId) {
                 if (otherPlr == nullptr || sockTo == nullptr)
                     continue;
 
-                if (otherPlr->instanceID == 0) {
-                    otherPlr->lastX = otherPlr->x;
-                    otherPlr->lastY = otherPlr->y;
-                    otherPlr->lastZ = otherPlr->z;
-                    otherPlr->lastAngle = otherPlr->angle;
-                }
-
                 PlayerManager::sendPlayerTo(sockTo, Warps[warpId].x, Warps[warpId].y, Warps[warpId].z, instanceID);
             }
         }

--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -407,14 +407,14 @@ bool doDebuff(CNSocket *sock, int32_t *pktdata, sSkillResult_Damage_N_Debuff *re
 
     Mob* mob = MobManager::Mobs[pktdata[i]];
 
-    int damage = MobManager::hitMob(sock, mob, amount);
+    int damage = MobManager::hitMob(sock, mob, 0); // using amount for something else
 
     respdata[i].eCT = 4;
     respdata[i].iDamage = damage;
     respdata[i].iID = mob->appearanceData.iNPC_ID;
     respdata[i].iHP = mob->appearanceData.iHP;
     respdata[i].iConditionBitFlag = mob->appearanceData.iConditionBitFlag |= iCBFlag;
-
+    mob->unbuffTimes[iCBFlag] = getTime() + amount;
     std::cout << (int)mob->appearanceData.iNPC_ID << " was debuffed" << std::endl;
 
     return true;
@@ -428,10 +428,12 @@ bool doBuff(CNSocket *sock, int32_t *pktdata, sSkillResult_Buff *respdata, int i
     }
 
     Mob* mob = MobManager::Mobs[pktdata[i]];
+    MobManager::hitMob(sock, mob, 0);
 
     respdata[i].eCT = 4;
     respdata[i].iID = mob->appearanceData.iNPC_ID;
     respdata[i].iConditionBitFlag = mob->appearanceData.iConditionBitFlag |= iCBFlag;
+    mob->unbuffTimes[iCBFlag] = getTime() + amount;
 
     std::cout << (int)mob->appearanceData.iNPC_ID << " was debuffed" << std::endl;
 
@@ -669,15 +671,15 @@ void activePower(CNSocket *sock, CNPacketData *data,
 
 // active nano power dispatch table
 std::vector<ActivePower> ActivePowers = {
-    ActivePower(StunPowers, activePower<sSkillResult_Damage_N_Debuff,  doDebuff>,         EST_STUN, CSB_BIT_STUN,                 0),
+    ActivePower(StunPowers, activePower<sSkillResult_Damage_N_Debuff,  doDebuff>,         EST_STUN, CSB_BIT_STUN,              2250),
     ActivePower(HealPowers, activePower<sSkillResult_Heal_HP,          doHeal>,           EST_HEAL_HP, CSB_BIT_NONE,             25),
-    ActivePower(GroupHealPowers, activePower<sSkillResult_Heal_HP,     doGroupHeal, GHEAL>,EST_HEAL_HP, CSB_BIT_NONE,            25),
+    ActivePower(GroupHealPowers, activePower<sSkillResult_Heal_HP,     doGroupHeal, GHEAL>,EST_HEAL_HP, CSB_BIT_NONE,            15),
     // TODO: Recall
-    ActivePower(DrainPowers, activePower<sSkillResult_Buff,            doBuff>,           EST_BOUNDINGBALL, CSB_BIT_BOUNDINGBALL, 0),
-    ActivePower(SnarePowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SNARE, CSB_BIT_DN_MOVE_SPEED,       0),
+    ActivePower(DrainPowers, activePower<sSkillResult_Buff,            doBuff>,        EST_BOUNDINGBALL, CSB_BIT_BOUNDINGBALL, 3000),
+    ActivePower(SnarePowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SNARE, CSB_BIT_DN_MOVE_SPEED,    4500),
     ActivePower(DamagePowers, activePower<sSkillResult_Damage,         doDamage>,         EST_DAMAGE, CSB_BIT_NONE,              12),
     ActivePower(LeechPowers, activePower<sSkillResult_Heal_HP,         doLeech, LEECH>,   EST_BLOODSUCKING, CSB_BIT_NONE,        18),
-    ActivePower(SleepPowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SLEEP, CSB_BIT_MEZ,                 0),
+    ActivePower(SleepPowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SLEEP, CSB_BIT_MEZ,              4500),
 };
 
 }; // namespace

--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -672,8 +672,8 @@ void activePower(CNSocket *sock, CNPacketData *data,
 // active nano power dispatch table
 std::vector<ActivePower> ActivePowers = {
     ActivePower(StunPowers, activePower<sSkillResult_Damage_N_Debuff,  doDebuff>,         EST_STUN, CSB_BIT_STUN,              2250),
-    ActivePower(HealPowers, activePower<sSkillResult_Heal_HP,          doHeal>,           EST_HEAL_HP, CSB_BIT_NONE,             25),
-    ActivePower(GroupHealPowers, activePower<sSkillResult_Heal_HP,     doGroupHeal, GHEAL>,EST_HEAL_HP, CSB_BIT_NONE,            15),
+    ActivePower(HealPowers, activePower<sSkillResult_Heal_HP,          doHeal>,           EST_HEAL_HP, CSB_BIT_NONE,             35),
+    ActivePower(GroupHealPowers, activePower<sSkillResult_Heal_HP,     doGroupHeal, GHEAL>,EST_HEAL_HP, CSB_BIT_NONE,            20),
     // TODO: Recall
     ActivePower(DrainPowers, activePower<sSkillResult_Buff,            doBuff>,        EST_BOUNDINGBALL, CSB_BIT_BOUNDINGBALL, 3000),
     ActivePower(SnarePowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SNARE, CSB_BIT_DN_MOVE_SPEED,    4500),

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -50,6 +50,7 @@ struct Player {
 
     bool inCombat;
     bool passiveNanoOut;
+    int healCooldown;
 
     int pointDamage;
     int groupDamage;

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -252,6 +252,7 @@ void PlayerManager::sendPlayerTo(CNSocket* sock, int X, int Y, int Z, uint64_t I
         PlayerManager::removePlayerFromChunks(plrv.currentChunks, sock);
         plrv.currentChunks.clear();
         sock->sendPacket((void*)&resp, P_FE2CL_REP_PC_WARP_USE_NPC_SUCC, sizeof(sP_FE2CL_REP_PC_WARP_USE_NPC_SUCC));
+        updatePlayerPosition(sock, X, Y, Z);
     }
 
     ChunkManager::destroyInstanceIfEmpty(fromInstance);
@@ -270,6 +271,7 @@ void PlayerManager::sendPlayerTo(CNSocket* sock, int X, int Y, int Z) {
     plrv.currentChunks.clear();
     plrv.chunkPos = std::make_tuple(0, 0, plrv.plr->instanceID);
     sock->sendPacket((void*)&pkt, P_FE2CL_REP_PC_GOTO_SUCC, sizeof(sP_FE2CL_REP_PC_GOTO_SUCC));
+    updatePlayerPosition(sock, X, Y, Z);
 }
 
 void PlayerManager::enterPlayer(CNSocket* sock, CNPacketData* data) {

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -271,7 +271,6 @@ void PlayerManager::sendPlayerTo(CNSocket* sock, int X, int Y, int Z) {
     plrv.currentChunks.clear();
     plrv.chunkPos = std::make_tuple(0, 0, plrv.plr->instanceID);
     sock->sendPacket((void*)&pkt, P_FE2CL_REP_PC_GOTO_SUCC, sizeof(sP_FE2CL_REP_PC_GOTO_SUCC));
-    updatePlayerPosition(sock, X, Y, Z);
 }
 
 void PlayerManager::enterPlayer(CNSocket* sock, CNPacketData* data) {


### PR DESCRIPTION
Main Changes:
* Warping into IZs and Fusion Lairs now will also take into account your group members.
* Mobs pursue their targets more smoothly, they will avoid phasing into the player during combat.
* Nerfed retreat speed by a factor of 1.5, normal mobs retreated way too quickly however mobs like Don Doom and Bad Max do not retreat fast enough.
* Bugfixed sendPlayerTo, it did not call updatePlayerPosition leaving undesirable anomalies.
* Nano drain power works, currently does 30% damage over a period of 3 seconds.
* Stun, Sleep and Snare powers will now run out of time on mobs.
* Weapons will consume your batteries fully.
* Players heal faster after a sizable cooldown.
* Nano type advantage is more noticeable during combat.
* Item delivery quests now work.
* Timed missions now work.
* All escort missions (type 6) are skipped.
* /minfo now also prints the terminator npc.
* Weapon battery consumption tweaked
* Heal nanos have better output (25% -> 35%)
* Damage formula had a slight tweak, armor matters more. Nerfed enemy damage at lower levels.
* Possibly fixed the weapon swapping bug.
* removed Herobrine

Codebase changes:
* MobManager lerp does not confusingly divide speed by 2 anymore.
* resendMobHP() has been repurposed to drainMobHP(), drain uses a static variable as a timer (lastDrainTime).