### PR TITLE
Moved Debuff handling to Combat + Bugfixes

### DIFF
--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -268,9 +268,9 @@ void ItemManager::itemUseHandler(CNSocket* sock, CNPacketData* data) {
     response.eIL = 1;
     response.iSlotNum = request->iSlotNum;
     response.RemainItem = gumball;
-   // response.iTargetCnt = ?
-   // response.eST = ?
-   // response.iSkillID = ?
+    // response.iTargetCnt = ?
+    // response.eST = ?
+    // response.iSkillID = ?
 
     sock->sendPacket((void*)&response, P_FE2CL_REP_PC_ITEM_USE_SUCC, sizeof(sP_FE2CL_REP_PC_ITEM_USE_SUCC));
     // update inventory serverside

--- a/src/MobManager.hpp
+++ b/src/MobManager.hpp
@@ -46,7 +46,7 @@ struct Mob : public BaseNPC {
     // combat
     CNSocket *target = nullptr;
     time_t nextAttack = 0;
-
+    time_t lastDrainTime = 0;
 
     // drop
     int dropType;
@@ -142,4 +142,5 @@ namespace MobManager {
     void drainMobHP(Mob *mob, int amount);
     void incNextMovement(Mob *mob, time_t currTime=0);
     bool aggroCheck(Mob *mob, time_t currTime);
+    void clearDebuff(Mob *mob);
 }

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -406,22 +406,25 @@ void NPCManager::npcVendorBuyBattery(CNSocket* sock, CNPacketData* data) {
     if (plr == nullptr)
         return;
 
-    int cost = req->Item.iOpt * 10;
+    int cost = req->Item.iOpt * 100;
     if ((req->Item.iID == 3 ? (plr->batteryW >= 9999) : (plr->batteryN >= 9999)) || plr->money < cost) { // sanity check
         INITSTRUCT(sP_FE2CL_REP_PC_VENDOR_BATTERY_BUY_FAIL, failResp);
         failResp.iErrorCode = 0;
         sock->sendPacket((void*)&failResp, P_FE2CL_REP_PC_VENDOR_BATTERY_BUY_FAIL, sizeof(sP_FE2CL_REP_PC_VENDOR_BATTERY_BUY_FAIL));
     }
 
-    plr->money -= cost;
-    plr->batteryW += req->Item.iID == 3 ? req->Item.iOpt * 10 : 0;
-    plr->batteryN += req->Item.iID == 4 ? req->Item.iOpt * 10 : 0;
+    cost = plr->batteryW + plr->batteryN;
+    plr->batteryW += req->Item.iID == 3 ? req->Item.iOpt * 100 : 0;
+    plr->batteryN += req->Item.iID == 4 ? req->Item.iOpt * 100 : 0;
 
     // caps
     if (plr->batteryW > 9999)
         plr->batteryW = 9999;
     if (plr->batteryN > 9999)
         plr->batteryN = 9999;
+
+    cost = plr->batteryW + plr->batteryN - cost;
+    plr->money -= cost;
 
     INITSTRUCT(sP_FE2CL_REP_PC_VENDOR_BATTERY_BUY_SUCC, resp);
 

--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -715,15 +715,15 @@ void activePower(CNSocket *sock, CNPacketData *data,
 
 // active nano power dispatch table
 std::vector<ActivePower> ActivePowers = {
-    ActivePower(StunPowers, activePower<sSkillResult_Damage_N_Debuff,  doDebuff>,         EST_STUN, CSB_BIT_STUN,              2250),
+    ActivePower(StunPowers, activePower<sSkillResult_Damage_N_Debuff,  doDebuff>,         EST_STUN, CSB_BIT_STUN,              4000),
     ActivePower(HealPowers, activePower<sSkillResult_Heal_HP,          doHeal>,           EST_HEAL_HP, CSB_BIT_NONE,             35),
     ActivePower(GroupHealPowers, activePower<sSkillResult_Heal_HP,     doGroupHeal, GHEAL>,EST_HEAL_HP, CSB_BIT_NONE,            20),
     // TODO: Recall
-    ActivePower(DrainPowers, activePower<sSkillResult_Buff,            doBuff>,        EST_BOUNDINGBALL, CSB_BIT_BOUNDINGBALL, 3000),
-    ActivePower(SnarePowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SNARE, CSB_BIT_DN_MOVE_SPEED,    4500),
+    ActivePower(DrainPowers, activePower<sSkillResult_Buff,            doBuff>,        EST_BOUNDINGBALL, CSB_BIT_BOUNDINGBALL, 6000),
+    ActivePower(SnarePowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SNARE, CSB_BIT_DN_MOVE_SPEED,    8000),
     ActivePower(DamagePowers, activePower<sSkillResult_Damage,         doDamage>,         EST_DAMAGE, CSB_BIT_NONE,              12),
     ActivePower(LeechPowers, activePower<sSkillResult_Heal_HP,         doLeech, LEECH>,   EST_BLOODSUCKING, CSB_BIT_NONE,        18),
-    ActivePower(SleepPowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SLEEP, CSB_BIT_MEZ,              4500),
+    ActivePower(SleepPowers, activePower<sSkillResult_Damage_N_Debuff, doDebuff>,         EST_SLEEP, CSB_BIT_MEZ,              8000),
 };
 
 }; // namespace


### PR DESCRIPTION
* Majority of mob debuff handling is moved to combatStep().
* Drain now kills the mob and does 40% overall damage.
* Bumped up active nano debuff durations, debuffs like drain linger longer but damage less.
* Debuffs are cleared upon mob death and retreating.
* Patched out vehicle off success packet spam
* Boosts and potions now cost the right amount (100 taros) and give the right quantity (100).
* Damage was tweaked slightly. At higher levels you are more likely to fall prey to rand().
* Enemies now use run animations during combat and retreating.