### PR TITLE
Nano Powers Refactor

### DIFF
--- a/src/GroupManager.cpp
+++ b/src/GroupManager.cpp
@@ -146,7 +146,7 @@ void GroupManager::joinGroup(CNSocket* sock, CNPacketData* data) {
         respdata[i].iZ = varPlr->z;
         // client doesnt read nano data here
 
-        if (varPlr != plr) {
+        if (varPlr != plr) { // apply the new member's buffs to the group and the group's buffs to the new member
             NanoManager::applyBuff(sock, varPlr->Nanos[varPlr->activeNano].iSkillID, 1, 1, bitFlag);
             NanoManager::applyBuff(sockTo, plr->Nanos[plr->activeNano].iSkillID, 1, 1, bitFlag);
         }
@@ -340,7 +340,7 @@ void GroupManager::groupKickPlayer(Player* plr) {
         if (varPlr == plr) {
             moveDown = 1;
             otherPlr->groupIDs[i] = 0;
-        } else {
+        } else { // remove the leaving member's buffs from the group and remove the group buffs from the leaving member.
             NanoManager::applyBuff(sock, varPlr->Nanos[varPlr->activeNano].iSkillID, 2, 1, 0);
             NanoManager::applyBuff(sockTo, plr->Nanos[plr->activeNano].iSkillID, 2, 1, bitFlag);
         }
@@ -360,7 +360,7 @@ void GroupManager::groupUnbuff(Player* plr) {
         for (int n = 0; n < plr->groupCnt; n++) {
             if (i == n)
                 continue;
-        
+
             Player* otherPlr = PlayerManager::getPlayerFromID(plr->groupIDs[i]);
             CNSocket* sock = PlayerManager::getSockFromID(plr->groupIDs[n]);
 

--- a/src/GroupManager.cpp
+++ b/src/GroupManager.cpp
@@ -147,8 +147,10 @@ void GroupManager::joinGroup(CNSocket* sock, CNPacketData* data) {
         // client doesnt read nano data here
 
         if (varPlr != plr) { // apply the new member's buffs to the group and the group's buffs to the new member
-            NanoManager::applyBuff(sock, varPlr->Nanos[varPlr->activeNano].iSkillID, 1, 1, bitFlag);
-            NanoManager::applyBuff(sockTo, plr->Nanos[plr->activeNano].iSkillID, 1, 1, bitFlag);
+            if (NanoManager::SkillTable[varPlr->Nanos[varPlr->activeNano].iSkillID].targetType == 3)
+                NanoManager::applyBuff(sock, varPlr->Nanos[varPlr->activeNano].iSkillID, 1, 1, bitFlag);
+            if (NanoManager::SkillTable[plr->Nanos[plr->activeNano].iSkillID].targetType == 3)
+                NanoManager::applyBuff(sockTo, plr->Nanos[plr->activeNano].iSkillID, 1, 1, bitFlag);
         }
     }
 
@@ -341,8 +343,10 @@ void GroupManager::groupKickPlayer(Player* plr) {
             moveDown = 1;
             otherPlr->groupIDs[i] = 0;
         } else { // remove the leaving member's buffs from the group and remove the group buffs from the leaving member.
-            NanoManager::applyBuff(sock, varPlr->Nanos[varPlr->activeNano].iSkillID, 2, 1, 0);
-            NanoManager::applyBuff(sockTo, plr->Nanos[plr->activeNano].iSkillID, 2, 1, bitFlag);
+            if (NanoManager::SkillTable[varPlr->Nanos[varPlr->activeNano].iSkillID].targetType == 3)
+                NanoManager::applyBuff(sock, varPlr->Nanos[varPlr->activeNano].iSkillID, 2, 1, 0);
+            if (NanoManager::SkillTable[plr->Nanos[varPlr->activeNano].iSkillID].targetType == 3)
+                NanoManager::applyBuff(sockTo, plr->Nanos[plr->activeNano].iSkillID, 2, 1, bitFlag);
         }
     }
 

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -266,7 +266,7 @@ void ItemManager::itemUseHandler(CNSocket* sock, CNPacketData* data) {
 
     size_t resplen = sizeof(sP_FE2CL_REP_PC_ITEM_USE_SUCC) + sizeof(sSkillResult_Buff);
 
-        // validate response packet
+    // validate response packet
     if (!validOutVarPacket(sizeof(sP_FE2CL_REP_PC_ITEM_USE_SUCC), 1, sizeof(sSkillResult_Buff))) {
         std::cout << "[WARN] bad sP_FE2CL_REP_PC_ITEM_USE_SUCC packet size" << std::endl;
         return;

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -286,13 +286,7 @@ void ItemManager::itemUseHandler(CNSocket* sock, CNPacketData* data) {
     resp->RemainItem = gumball;
     resp->iTargetCnt = 1;
     resp->eST = EST_NANOSTIMPAK;
-
-    if (request->iNanoSlot == 1)
-        resp->iSkillID = 191;
-    else if (request->iNanoSlot == 2)
-        resp->iSkillID = 197;
-    else
-        resp->iSkillID = 144;
+    resp->iSkillID = 144;
 
     int value1 = CSB_BIT_STIMPAKSLOT1 << request->iNanoSlot;
     int value2 = ECSB_STIMPAKSLOT1 + request->iNanoSlot;
@@ -312,8 +306,8 @@ void ItemManager::itemUseHandler(CNSocket* sock, CNPacketData* data) {
     // update inventory serverside
     player->Inven[resp->iSlotNum] = resp->RemainItem;
 
-    std::pair<CNSocket*, int32_t> key = std::make_pair(sock, resp->iSkillID);
-    time_t until = getTime() + (time_t)NanoManager::SkillTable[resp->iSkillID].durationTime[0] * 10;
+    std::pair<CNSocket*, int32_t> key = std::make_pair(sock, value1);
+    time_t until = getTime() + (time_t)NanoManager::SkillTable[144].durationTime[0] * 10;
     NPCManager::EggBuffs[key] = until;
 }
 

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -398,14 +398,14 @@ int MissionManager::giveMissionReward(CNSocket *sock, int task) {
     plr->money += reward->money;
     if (plr->iConditionBitFlag & CSB_BIT_REWARD_CASH) { // nano boost for taros
         int boost = 0;
-        if (NanoManager::getNanoBoost(plr))
+        if (NanoManager::getNanoBoost(plr)) // for gumballs
             boost = 1;
         plr->money += reward->money * (5 + boost) / 25;
     }
 
     if (plr->iConditionBitFlag & CSB_BIT_REWARD_BLOB) { // nano boost for fm
         int boost = 0;
-        if (NanoManager::getNanoBoost(plr))
+        if (NanoManager::getNanoBoost(plr)) // for gumballs
             boost = 1;
         updateFusionMatter(sock, reward->fusionmatter * (30 + boost) / 25);
     } else

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -396,7 +396,20 @@ int MissionManager::giveMissionReward(CNSocket *sock, int task) {
 
     // update player
     plr->money += reward->money;
-    updateFusionMatter(sock, reward->fusionmatter);
+    if (plr->iConditionBitFlag & CSB_BIT_REWARD_CASH) { // nano boost for taros
+        int boost = 0;
+        if (NanoManager::getNanoBoost(plr))
+            boost = 1;
+        plr->money += reward->money * (5 + boost) / 25;
+    }
+
+    if (plr->iConditionBitFlag & CSB_BIT_REWARD_BLOB) { // nano boost for fm
+        int boost = 0;
+        if (NanoManager::getNanoBoost(plr))
+            boost = 1;
+        updateFusionMatter(sock, reward->fusionmatter * (30 + boost) / 25);
+    } else
+        updateFusionMatter(sock, reward->fusionmatter);
 
     // simple rewards
     resp->m_iCandy = plr->money;

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -505,7 +505,7 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
 
     // drain
     if ((mob->lastDrainTime == 0 || currTime - mob->lastDrainTime >= 1000) && mob->appearanceData.iConditionBitFlag & CSB_BIT_BOUNDINGBALL) {
-        drainMobHP(mob, mob->maxHealth / 15); // lose 6.67% every second
+        drainMobHP(mob, mob->maxHealth / 20); // lose 5% every second
         mob->lastDrainTime = currTime;
     }
 
@@ -934,10 +934,7 @@ void MobManager::playerTick(CNServer *serv, time_t currTime) {
 
         for (int i = 0; i < 3; i++) {
             if (plr->activeNano != 0 && plr->equippedNanos[i] == plr->activeNano) { // spend stamina
-                plr->Nanos[plr->activeNano].iStamina -= 1;
-
-                if (plr->passiveNanoOut)
-                   plr->Nanos[plr->activeNano].iStamina -= 1;
+                plr->Nanos[plr->activeNano].iStamina -= 1 + plr->nanoDrainRate * 2 / 5;
 
                 if (plr->Nanos[plr->activeNano].iStamina <= 0) {
                     plr->Nanos[plr->activeNano].iStamina = 0;

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -986,7 +986,11 @@ std::pair<int,int> MobManager::getDamage(int attackPower, int defensePower, bool
 
     // Adaptium/Blastons/Cosmix
     if (attackerStyle != -1 && defenderStyle != -1 && attackerStyle != defenderStyle) {
-        if (attackerStyle < defenderStyle || attackerStyle - defenderStyle == 2) 
+        if (attackerStyle - defenderStyle == 2)
+            defenderStyle += 3;
+        if (defenderStyle - attackerStyle == 2)
+            defenderStyle -= 3;
+        if (attackerStyle < defenderStyle) 
             damage = damage * 3 / 2;
         else
             damage = damage * 2 / 3;

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -847,7 +847,7 @@ void MobManager::dotDamageOnOff(CNSocket *sock, CNPacketData *data) {
     pkt1.eCSTB = ECSB_INFECTION; // eCharStatusTimeBuffID
     pkt1.eTBU = 1; // eTimeBuffUpdate
     pkt1.eTBT = 0; // eTimeBuffType 1 means nano
-    pkt1.iConditionBitFlag = plr->iConditionBitFlag | plr->iGroupConditionBitFlag | plr->iEggConditionBitFlag;
+    pkt1.iConditionBitFlag = plr->iConditionBitFlag;
 
     sock->sendPacket((void*)&pkt1, P_FE2CL_PC_BUFF_UPDATE, sizeof(sP_FE2CL_PC_BUFF_UPDATE));
 }
@@ -895,7 +895,7 @@ void MobManager::dealGooDamage(CNSocket *sock, int amount) {
     dmg->iID = plr->iID;
     dmg->iDamage = amount;
     dmg->iHP = plr->HP;
-    dmg->iConditionBitFlag = plr->iConditionBitFlag | plr->iGroupConditionBitFlag | plr->iEggConditionBitFlag;
+    dmg->iConditionBitFlag = plr->iConditionBitFlag;
 
     sock->sendPacket((void*)&respbuf, P_FE2CL_CHAR_TIME_BUFF_TIME_TICK, resplen);
     PlayerManager::sendToViewable(sock, (void*)&respbuf, P_FE2CL_CHAR_TIME_BUFF_TIME_TICK, resplen);

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -582,7 +582,7 @@ int NPCManager::eggBuffPlayer(CNSocket* sock, int skillId, int eggId) {
     int bitFlag = GroupManager::getGroupFlags(otherPlr);
 
     if (EggBuffs.find(key) == EggBuffs.end())
-        if (!NanoManager::applyBuff(sock, skillId, 1, 3, bitFlag, true))
+        if (!NanoManager::applyBuff(sock, skillId, 1, 3, bitFlag))
             return -1;
 
     // save the buff serverside;
@@ -719,7 +719,7 @@ void NPCManager::eggPickup(CNSocket* sock, CNPacketData* data) {
         sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK* pkt = (sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK*)respbuf;
         sSkillResult_Damage* dmg = (sSkillResult_Damage*)(respbuf + sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_TICK));
 
-        dmg->iDamage = PC_MAXHEALTH(plr->level) * 6 / 10;
+        dmg->iDamage = PC_MAXHEALTH(plr->level) * 73 / 100;
 
         plr->HP -= dmg->iDamage;
 

--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -536,9 +536,22 @@ int* NanoManager::findTargets(Player* plr, int skillID, CNPacketData* data) {
         if (otherPlr == nullptr)
             return tD;
 
-        tD[0] = otherPlr->groupCnt;
-        for (int i = 0; i < otherPlr->groupCnt; i++)
-            tD[i+1] = otherPlr->groupIDs[i];
+        if (SkillTable[skillID].effectArea == 0) { // for buffs
+            tD[0] = otherPlr->groupCnt;
+            for (int i = 0; i < otherPlr->groupCnt; i++)
+                tD[i+1] = otherPlr->groupIDs[i];
+            return tD;
+        }
+
+        for (int i = 0; i < otherPlr->groupCnt; i++) { // group heals have an area limit
+            Player *otherPlr2 = PlayerManager::getPlayerFromID(otherPlr->groupIDs[i]);
+            if (otherPlr2 == nullptr)
+                continue;
+            if (hypot(otherPlr2->x - plr->x, otherPlr2->y - plr->y) < SkillTable[skillID].effectArea) {
+                tD[i+1] = otherPlr->groupIDs[i];
+                tD[0] += 1;
+            }
+        }
     }
     
     return tD;

--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -900,7 +900,9 @@ std::vector<NanoPower> NanoPowers = {
     NanoPower(EST_RECALL_GROUP,     CSB_BIT_NONE,              ECSB_NONE,              nanoPower<sSkillResult_Move,                     doMove>),
     NanoPower(EST_RETROROCKET_SELF, CSB_BIT_NONE,              ECSB_NONE,              nanoPower<sSkillResult_Buff,                     doBuff>),
     NanoPower(EST_PHOENIX_GROUP,    CSB_BIT_NONE,              ECSB_NONE,              nanoPower<sSkillResult_Resurrect,           doResurrect>),
-    NanoPower(EST_NANOSTIMPAK,      CSB_BIT_STIMPAKSLOT1,      ECSB_STIMPAKSLOT1,      nanoPower<sSkillResult_Buff,                     doBuff>)
+    NanoPower(EST_NANOSTIMPAK,      CSB_BIT_STIMPAKSLOT1,      ECSB_STIMPAKSLOT1,      nanoPower<sSkillResult_Buff,                     doBuff>),
+    NanoPower(EST_NANOSTIMPAK,      CSB_BIT_STIMPAKSLOT2,      ECSB_STIMPAKSLOT2,      nanoPower<sSkillResult_Buff,                     doBuff>),
+    NanoPower(EST_NANOSTIMPAK,      CSB_BIT_STIMPAKSLOT3,      ECSB_STIMPAKSLOT3,      nanoPower<sSkillResult_Buff,                     doBuff>)
 };
 
 }; // namespace

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -65,7 +65,7 @@ namespace NanoManager {
     void setNanoSkill(CNSocket* sock, sP_CL2FE_REQ_NANO_TUNE* skill);
     void resetNanoSkill(CNSocket* sock, int16_t nanoID);
     void nanoUnbuff(CNSocket* sock, int* targetData, int32_t bitFlag, int16_t timeBuffID, int16_t amount, bool groupPower);
-    void applyBuff(CNSocket* sock, int skillID, int eTBU, int eTBT, int32_t groupFlags);
+    bool applyBuff(CNSocket* sock, int skillID, int eTBU, int eTBT, int32_t groupFlags, bool eggBuff=false);
     int nanoStyle(int nanoID);
     int* findTargets(Player* plr, int skillID, CNPacketData* data = nullptr);
 }

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -36,6 +36,7 @@ struct SkillData {
     int skillType;
     int targetType;
     int drainType;
+    int effectArea;
     int batteryUse[4];
     int durationTime[4];
     int powerIntensity[4];

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -65,7 +65,7 @@ namespace NanoManager {
     void setNanoSkill(CNSocket* sock, sP_CL2FE_REQ_NANO_TUNE* skill);
     void resetNanoSkill(CNSocket* sock, int16_t nanoID);
     void nanoUnbuff(CNSocket* sock, int* targetData, int32_t bitFlag, int16_t timeBuffID, int16_t amount, bool groupPower);
-    bool applyBuff(CNSocket* sock, int skillID, int eTBU, int eTBT, int32_t groupFlags);
+    int applyBuff(CNSocket* sock, int skillID, int eTBU, int eTBT, int32_t groupFlags);
     int nanoStyle(int nanoID);
     int* findTargets(Player* plr, int skillID, CNPacketData* data = nullptr);
 }

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -65,7 +65,7 @@ namespace NanoManager {
     void setNanoSkill(CNSocket* sock, sP_CL2FE_REQ_NANO_TUNE* skill);
     void resetNanoSkill(CNSocket* sock, int16_t nanoID);
     void nanoUnbuff(CNSocket* sock, int* targetData, int32_t bitFlag, int16_t timeBuffID, int16_t amount, bool groupPower);
-    bool applyBuff(CNSocket* sock, int skillID, int eTBU, int eTBT, int32_t groupFlags, bool eggBuff=false);
+    bool applyBuff(CNSocket* sock, int skillID, int eTBU, int eTBT, int32_t groupFlags);
     int nanoStyle(int nanoID);
     int* findTargets(Player* plr, int skillID, CNPacketData* data = nullptr);
 }

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -5,37 +5,22 @@
 
 #include "CNShardServer.hpp"
 
-struct TargetData {
-    int targetID[4];
-};
+typedef void (*PowerHandler)(CNSocket*, int*, int16_t, int16_t, int16_t, int16_t, int16_t, int32_t, int16_t);
 
-typedef void (*PowerHandler)(CNSocket*, TargetData, int16_t, int16_t, int16_t, int16_t, int16_t, int32_t, int16_t);
-
-struct ActivePower {
+struct NanoPower {
     int16_t skillType;
     int32_t bitFlag;
     int16_t timeBuffID;
     PowerHandler handler;
 
-    ActivePower(int16_t s, int32_t b, int16_t t, PowerHandler h) : skillType(s), bitFlag(b), timeBuffID(t), handler(h) {}
+    NanoPower(int16_t s, int32_t b, int16_t t, PowerHandler h) : skillType(s), bitFlag(b), timeBuffID(t), handler(h) {}
 
-    void handle(CNSocket *sock, TargetData targetData, int16_t nanoID, int16_t skillID, int16_t duration, int16_t amount) {
+    void handle(CNSocket *sock, int* targetData, int16_t nanoID, int16_t skillID, int16_t duration, int16_t amount) {
         if (handler == nullptr)
             return;
 
         handler(sock, targetData, nanoID, skillID, duration, amount, skillType, bitFlag, timeBuffID);
     }
-};
-
-struct PassivePower {
-    std::set<int> powers;
-    int16_t eSkillType;
-    int32_t iCBFlag;
-    int16_t eCharStatusTimeBuffID;
-    int16_t iValue;
-    bool groupPower;
-
-    PassivePower(std::set<int> p, int16_t t, int32_t f, int16_t b, int16_t a, bool g) : powers(p), eSkillType(t), iCBFlag(f), eCharStatusTimeBuffID(b), iValue(a), groupPower(g) {}
 };
 
 struct NanoData {
@@ -57,8 +42,7 @@ struct SkillData {
 };
 
 namespace NanoManager {
-    extern std::vector<ActivePower> ActivePowers;
-    extern std::vector<PassivePower> PassivePowers;
+    extern std::vector<NanoPower> NanoPowers;
     extern std::map<int32_t, NanoData> NanoTable;
     extern std::map<int32_t, NanoTuning> NanoTunings;
     extern std::map<int32_t, SkillData> SkillTable;
@@ -80,7 +64,8 @@ namespace NanoManager {
     void summonNano(CNSocket* sock, int slot);
     void setNanoSkill(CNSocket* sock, sP_CL2FE_REQ_NANO_TUNE* skill);
     void resetNanoSkill(CNSocket* sock, int16_t nanoID);
-    void nanoUnbuff(CNSocket* sock, TargetData targetData, int32_t bitFlag, int16_t timeBuffID, int16_t amount, bool groupPower);
+    void nanoUnbuff(CNSocket* sock, int* targetData, int32_t bitFlag, int16_t timeBuffID, int16_t amount, bool groupPower);
     void applyBuff(CNSocket* sock, int skillID, int eTBU, int eTBT, int32_t groupFlags);
     int nanoStyle(int nanoID);
+    int* findTargets(Player* plr, int skillID, CNPacketData* data = nullptr);
 }

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -44,11 +44,20 @@ struct NanoTuning {
     int reqItems;
 };
 
+struct SkillData {
+    int skillType;
+    int targetType;
+    int batteryUse[4];
+    int durationTime[4];
+    int powerIntensity[4];
+};
+
 namespace NanoManager {
     extern std::vector<ActivePower> ActivePowers;
     extern std::vector<PassivePower> PassivePowers;
     extern std::map<int32_t, NanoData> NanoTable;
     extern std::map<int32_t, NanoTuning> NanoTunings;
+    extern std::map<int32_t, SkillData> SkillTable;
     void init();
 
     void nanoSummonHandler(CNSocket* sock, CNPacketData* data);

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -68,4 +68,5 @@ namespace NanoManager {
     int applyBuff(CNSocket* sock, int skillID, int eTBU, int eTBT, int32_t groupFlags);
     int nanoStyle(int nanoID);
     int* findTargets(Player* plr, int skillID, CNPacketData* data = nullptr);
+    bool getNanoBoost(Player* plr);
 }

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -74,8 +74,6 @@ struct Player {
     int32_t groupIDs[4];
     int32_t iGroupConditionBitFlag;
 
-    int32_t iEggConditionBitFlag;
-
     bool notify;
 
     bool buddiesSynced;

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -36,10 +36,12 @@ struct Player {
     int32_t iWarpLocationFlag;
     int64_t aSkywayLocationFlag[2];
     int32_t iConditionBitFlag;
+    int32_t iSelfConditionBitFlag;
     int8_t iSpecialState;
 
     int x, y, z, angle;
     int lastX, lastY, lastZ, lastAngle;
+    int recallX, recallY, recallZ, recallInstance;
     uint64_t instanceID;
     sItemBase Equip[AEQUIP_COUNT];
     sItemBase Inven[AINVEN_COUNT];
@@ -50,8 +52,9 @@ struct Player {
     bool isTradeConfirm;
 
     bool inCombat;
+
     bool onMonkey;
-    bool passiveNanoOut;
+    int nanoDrainRate = 0;
     int healCooldown;
 
     int pointDamage;

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -712,16 +712,12 @@ void PlayerManager::revivePlayer(CNSocket* sock, CNPacketData* data) {
 
     bool move = false;
 
-    if (reviveData->iRegenType == 3 && plr->iConditionBitFlag & CSB_BIT_PHOENIX || reviveData->iRegenType == 4) {
+    if (reviveData->iRegenType == 3 && plr->iConditionBitFlag & CSB_BIT_PHOENIX) {
         // nano revive
         plr->Nanos[plr->activeNano].iStamina = 0;
-
-        INITSTRUCT(TargetData, targetData);
-        targetData.targetID[0] = plr->iID;
-        for (int i = 1; i < 4; i++)
-            targetData.targetID[i] = -1;
-        NanoManager::nanoUnbuff(sock, targetData, CSB_BIT_PHOENIX, ECSB_PHOENIX, 0, false);
-
+        plr->HP = PC_MAXHEALTH(plr->level);
+        NanoManager::applyBuff(sock, plr->Nanos[plr->activeNano].iSkillID, 2, 1, 0);
+    } else if (reviveData->iRegenType == 4) {
         plr->HP = PC_MAXHEALTH(plr->level);
     } else {
         move = true;

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -712,10 +712,16 @@ void PlayerManager::revivePlayer(CNSocket* sock, CNPacketData* data) {
 
     bool move = false;
 
-    if (reviveData->iRegenType == 3 && plr->iConditionBitFlag & CSB_BIT_PHOENIX) {
+    if (reviveData->iRegenType == 3 && plr->iConditionBitFlag & CSB_BIT_PHOENIX || reviveData->iRegenType == 4) {
         // nano revive
         plr->Nanos[plr->activeNano].iStamina = 0;
-        NanoManager::nanoUnbuff(sock, CSB_BIT_PHOENIX, ECSB_PHOENIX, 0, false);
+
+        INITSTRUCT(TargetData, targetData);
+        targetData.targetID[0] = plr->iID;
+        for (int i = 1; i < 4; i++)
+            targetData.targetID[i] = -1;
+        NanoManager::nanoUnbuff(sock, targetData, CSB_BIT_PHOENIX, ECSB_PHOENIX, 0, false);
+
         plr->HP = PC_MAXHEALTH(plr->level);
     } else {
         move = true;

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -762,7 +762,13 @@ void PlayerManager::revivePlayer(CNSocket* sock, CNPacketData* data) {
     resp2.PCRegenDataForOtherPC.iZ = plr->z;
     resp2.PCRegenDataForOtherPC.iHP = plr->HP;
     resp2.PCRegenDataForOtherPC.iAngle = plr->angle;
-    resp2.PCRegenDataForOtherPC.iConditionBitFlag = plr->iConditionBitFlag;
+
+    Player *otherPlr = PlayerManager::getPlayerFromID(plr->iIDGroup);
+    if (otherPlr == nullptr)
+        return;
+    int bitFlag = GroupManager::getGroupFlags(otherPlr);
+    resp2.PCRegenDataForOtherPC.iConditionBitFlag = plr->iConditionBitFlag = plr->iSelfConditionBitFlag | bitFlag;
+
     resp2.PCRegenDataForOtherPC.iPCState = plr->iPCState;
     resp2.PCRegenDataForOtherPC.iSpecialState = plr->iSpecialState;
     resp2.PCRegenDataForOtherPC.Nano = plr->Nanos[plr->activeNano];

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -721,20 +721,18 @@ void PlayerManager::revivePlayer(CNSocket* sock, CNPacketData* data) {
         plr->HP = PC_MAXHEALTH(plr->level);
     } else {
         move = true;
-
         if (reviveData->iRegenType != 5)
             plr->HP = PC_MAXHEALTH(plr->level);
+    }
 
-        for (int i = 0; i < 3; i++) {
-            int nanoID = plr->equippedNanos[i];
-
-            // halve nano health if respawning
-            if (reviveData->iRegenType != 5)
-                plr->Nanos[nanoID].iStamina = 75; // max is 150, so 75 is half
-            response.PCRegenData.Nanos[i] = plr->Nanos[nanoID];
-            if (plr->activeNano == nanoID)
-                activeSlot = i;
-        }
+    for (int i = 0; i < 3; i++) {
+        int nanoID = plr->equippedNanos[i];
+        // halve nano health if respawning
+        if (reviveData->iRegenType == 6)
+            plr->Nanos[nanoID].iStamina = 75; // max is 150, so 75 is half
+        response.PCRegenData.Nanos[i] = plr->Nanos[nanoID];
+        if (plr->activeNano == nanoID)
+            activeSlot = i;
     }
 
     // Response parameters

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -190,6 +190,22 @@ void TableData::init() {
 
         std::cout << "[INFO] Loaded " << NanoManager::NanoTable.size() << " nano tunings" << std::endl;
 
+        // load nano powers
+        nlohmann::json skills = xdtData["m_pSkillTable"]["m_pSkillData"];
+
+        for (nlohmann::json::iterator _skills = skills.begin(); _skills != skills.end(); _skills++) {
+            auto skills = _skills.value();
+            SkillData skillData = {skills["m_iSkillType"], skills["m_iTargetType"]};
+            for (int i = 0; i < 4; i++) {
+                skillData.batteryUse[i] = skills["m_iBatteryDrainUse"][i];
+                skillData.durationTime[i] = skills["m_iDurationTime"][i];
+                skillData.powerIntensity[i] = skills["m_iValueA"][i];
+            }
+            NanoManager::SkillTable[skills["m_iSkillNumber"]] = skillData;
+        }
+
+        std::cout << "[INFO] Loaded " << NanoManager::SkillTable.size() << " nano skills" << std::endl;
+
     }
     catch (const std::exception& err) {
         std::cerr << "[FATAL] Malformed xdt.json file! Reason:" << err.what() << std::endl;

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -195,7 +195,7 @@ void TableData::init() {
 
         for (nlohmann::json::iterator _skills = skills.begin(); _skills != skills.end(); _skills++) {
             auto skills = _skills.value();
-            SkillData skillData = {skills["m_iSkillType"], skills["m_iTargetType"]};
+            SkillData skillData = {skills["m_iSkillType"], skills["m_iTargetType"], skills["m_iBatteryDrainType"]};
             for (int i = 0; i < 4; i++) {
                 skillData.batteryUse[i] = skills["m_iBatteryDrainUse"][i];
                 skillData.durationTime[i] = skills["m_iDurationTime"][i];

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -195,7 +195,7 @@ void TableData::init() {
 
         for (nlohmann::json::iterator _skills = skills.begin(); _skills != skills.end(); _skills++) {
             auto skills = _skills.value();
-            SkillData skillData = {skills["m_iSkillType"], skills["m_iTargetType"], skills["m_iBatteryDrainType"]};
+            SkillData skillData = {skills["m_iSkillType"], skills["m_iTargetType"], skills["m_iBatteryDrainType"], skills["m_iEffectArea"]};
             for (int i = 0; i < 4; i++) {
                 skillData.batteryUse[i] = skills["m_iBatteryDrainUse"][i];
                 skillData.durationTime[i] = skills["m_iDurationTime"][i];


### PR DESCRIPTION
* Nano powers now make use of the xdt to get the right values.
* All nano power functions have been merged into one goliath of a function.
* Nano powers consume the correct amount of stamina.
* Bugfixed gumball issues, gumballed nanos now perform better.
* Revive powers now work correctly.
* Recall powers both self and group are functional.
* Removed nanoBuff.
* Added a new applyBuff function, this allows for quick and easy application of nano skills.
* Adapted eggs to nano power data.
* Gumballs now run out of timer.
* Nano matchups now work correctly.
* A bunch of minor tweaks and bugfixes.
* Scavenge and Bonus nanos work.
* Eggs now damage and heal more cleanly.
* Group heal has a range limit.