### PR TITLE
Various bugfixes and tweaks

### DIFF
--- a/src/ChatManager.cpp
+++ b/src/ChatManager.cpp
@@ -446,6 +446,9 @@ void minfoCommand(std::string full, std::vector<std::string>& args, CNSocket* so
                 ChatManager::sendServerMessage(sock, "[MINFO] Current waypoint NPC ID: " + std::to_string((int)(task["m_iSTGrantWayPoint"])));
                 ChatManager::sendServerMessage(sock, "[MINFO] Current terminator NPC ID: " + std::to_string((int)(task["m_iHTerminatorNPCID"])));
 
+                if ((int)(task["m_iSTGrantTimer"]) != 0)
+                    ChatManager::sendServerMessage(sock, "[MINFO] Current task timer: " + std::to_string((int)(task["m_iSTGrantTimer"])));
+
                 for (int j = 0; j < 3; j++)
                     if ((int)(task["m_iCSUEnemyID"][j]) != 0)
                         ChatManager::sendServerMessage(sock, "[MINFO] Current task mob #" + std::to_string(j+1) +": " + std::to_string((int)(task["m_iCSUEnemyID"][j])));

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -110,7 +110,7 @@ void MissionManager::taskEnd(CNSocket* sock, CNPacketData* data) {
     if (missionData->iNPC_ID == 0) {
         TaskData* task = MissionManager::Tasks[missionData->iTaskNum];
         // double-checking
-        if (task->task["m_iHTaskType"] == 3) {
+        if (task->task["m_iSTGrantTimer"] > 0) {
             Player* plr = PlayerManager::getPlayer(sock);
             int failTaskID = task->task["m_iFOutgoingTask"];
             if (failTaskID != 0) {

--- a/src/MobManager.cpp
+++ b/src/MobManager.cpp
@@ -559,7 +559,7 @@ void MobManager::combatStep(Mob *mob, time_t currTime) {
     int mobRange = (int)mob->data["m_iAtkRange"] + (int)mob->data["m_iRadius"];
 
     if (currTime >= mob->nextAttack) {
-        if (mob->skillStyle != -1 || distance <= mobRange || rand() % 20 == 0) // while not in attack range, 1 / 10 chance.
+        if (mob->skillStyle != -1 || distance <= mobRange || rand() % 20 == 0) // while not in attack range, 1 / 20 chance.
             useAbilities(mob, currTime);
         if (mob->target == nullptr)
             return;
@@ -913,7 +913,7 @@ void MobManager::dealGooDamage(CNSocket *sock, int amount) {
         if (plr->Nanos[plr->activeNano].iStamina <= 0) {
             dmg->bNanoDeactive = 1;
             plr->Nanos[plr->activeNano].iStamina = 0;
-            NanoManager::summonNano(PlayerManager::getSockFromID(plr->iID), -1);
+            NanoManager::summonNano(PlayerManager::getSockFromID(plr->iID), -1, true);
         }
     }
 
@@ -967,7 +967,7 @@ void MobManager::playerTick(CNServer *serv, time_t currTime) {
                 plr->Nanos[plr->activeNano].iStamina -= 1 + plr->nanoDrainRate / 5;
 
                 if (plr->Nanos[plr->activeNano].iStamina <= 0)
-                    NanoManager::summonNano(sock, -1); // unsummon nano
+                    NanoManager::summonNano(sock, -1, true); // unsummon nano silently
 
                 transmit = true;
             } else if (plr->Nanos[plr->equippedNanos[i]].iStamina < 150) { // regain stamina
@@ -1634,8 +1634,10 @@ void MobManager::dealCorruption(Mob *mob, std::vector<int> targetData, int skill
             respdata[i].iHitFlag = 16; // lose
             respdata[i].iDamage = NanoManager::SkillTable[skillID].powerIntensity[0] * PC_MAXHEALTH((int)mob->data["m_iNpcLevel"]) / 1500;
             respdata[i].iNanoStamina = plr->Nanos[plr->activeNano].iStamina -= 90;
-            if (plr->Nanos[plr->activeNano].iStamina < 0)
+            if (plr->Nanos[plr->activeNano].iStamina < 0) {
+                respdata[i].bNanoDeactive = 1;
                 respdata[i].iNanoStamina = plr->Nanos[plr->activeNano].iStamina = 0;
+            }
         }
 
         respdata[i].iHP = plr->HP-= respdata[i].iDamage;

--- a/src/NanoManager.cpp
+++ b/src/NanoManager.cpp
@@ -291,7 +291,7 @@ void NanoManager::addNano(CNSocket* sock, int16_t nanoID, int16_t slot, bool spe
     PlayerManager::sendToViewable(sock, (void*)&resp2, P_FE2CL_REP_PC_CHANGE_LEVEL, sizeof(sP_FE2CL_REP_PC_CHANGE_LEVEL));
 }
 
-void NanoManager::summonNano(CNSocket *sock, int slot) {
+void NanoManager::summonNano(CNSocket *sock, int slot, bool silent) {
     INITSTRUCT(sP_FE2CL_REP_NANO_ACTIVE_SUCC, resp);
     resp.iActiveNanoSlotNum = slot;
     Player *plr = PlayerManager::getPlayer(sock);
@@ -338,9 +338,10 @@ void NanoManager::summonNano(CNSocket *sock, int slot) {
         }
     }
 
-    sock->sendPacket((void*)&resp, P_FE2CL_REP_NANO_ACTIVE_SUCC, sizeof(sP_FE2CL_REP_NANO_ACTIVE_SUCC));
+    if (!silent) // silent nano death but only for the summoning player
+        sock->sendPacket((void*)&resp, P_FE2CL_REP_NANO_ACTIVE_SUCC, sizeof(sP_FE2CL_REP_NANO_ACTIVE_SUCC));
 
-    // Send to other players
+    // Send to other players, these players can't handle silent nano deaths so this packet needs to be sent.
     INITSTRUCT(sP_FE2CL_NANO_ACTIVE, pkt1);
     pkt1.iPC_ID = plr->iID;
     pkt1.Nano = plr->Nanos[nanoID];

--- a/src/NanoManager.hpp
+++ b/src/NanoManager.hpp
@@ -62,7 +62,7 @@ namespace NanoManager {
 
     // Helper methods
     void addNano(CNSocket* sock, int16_t nanoID, int16_t slot, bool spendfm=false);
-    void summonNano(CNSocket* sock, int slot);
+    void summonNano(CNSocket* sock, int slot, bool silent = false);
     void setNanoSkill(CNSocket* sock, sP_CL2FE_REQ_NANO_TUNE* skill);
     void resetNanoSkill(CNSocket* sock, int16_t nanoID);
     void nanoUnbuff(CNSocket* sock, std::vector<int> targetData, int32_t bitFlag, int16_t timeBuffID, int16_t amount, bool groupPower);

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -728,7 +728,8 @@ void PlayerManager::revivePlayer(CNSocket* sock, CNPacketData* data) {
     for (int i = 0; i < 3; i++) {
         int nanoID = plr->equippedNanos[i];
         // halve nano health if respawning
-        if (reviveData->iRegenType == 6)
+        // all revives not 3-5 are normal respawns.
+        if (reviveData->iRegenType < 3 && reviveData->iRegenType > 5)
             plr->Nanos[nanoID].iStamina = 75; // max is 150, so 75 is half
         response.PCRegenData.Nanos[i] = plr->Nanos[nanoID];
         if (plr->activeNano == nanoID)


### PR DESCRIPTION
- timed missions of all types should work.
- nanos now transmit an unsummon(silent for the summoner) on 0 stamina.
- dying bumps your nanos down to half stamina now.
- enemies use abilities less frequently.
- group recall now works at any distance.
- passive nanos are tweaked to guzzle less stamina.
- cleared out some redundant stuff at the nanoPower handler.
- gumballs now last 10 minutes.