### PR TITLE
Added checks to prevent buddy warping and item sending across time

### DIFF
--- a/src/BuddyManager.cpp
+++ b/src/BuddyManager.cpp
@@ -659,13 +659,10 @@ void BuddyManager::emailSend(CNSocket* sock, CNPacketData* data) {
 
     INITSTRUCT(sP_FE2CL_REP_PC_SEND_EMAIL_SUCC, resp);
 
-    // handle items
-    std::vector<sItemBase> attachments;
-
     if (pkt->iCash || pkt->aItem[0].ItemInven.iID) {
         // if there are item or taro attachments
-        Player* otherPlr = PlayerManager::getPlayerFromID(pkt->iTo_PCUID);
-        if (plr->PCStyle2.iPayzoneFlag != otherPlr->PCStyle2.iPayzoneFlag) {
+        Database::DbPlayer otherPlayerData = Database::getDbPlayerById(pkt->iTo_PCUID);
+        if (plr->PCStyle2.iPayzoneFlag != otherPlayerData.PayZoneFlag) {
             // if the players are not in the same time period
             INITSTRUCT(sP_FE2CL_REP_PC_SEND_EMAIL_FAIL, resp);
             resp.iErrorCode = 9; //error code 9 tells the player they can't send attachments across time
@@ -674,6 +671,9 @@ void BuddyManager::emailSend(CNSocket* sock, CNPacketData* data) {
             return;
         }
     }
+
+    // handle items
+    std::vector<sItemBase> attachments;
 
     for (int i = 0; i < 4; i++) {
         sEmailItemInfoFromCL attachment = pkt->aItem[i];


### PR DESCRIPTION
Buddy warps and email attachments now require both players to be in the same time period (have changed their guide)