### PR TITLE
Better drop and RNG handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ CXXSRC=\
 	src/Racing.cpp\
 	src/Vendors.cpp\
 	src/Trading.cpp\
+	src/Rand.cpp\
 
 # headers (for timestamp purposes)
 CXXHDR=\
@@ -117,6 +118,7 @@ CXXHDR=\
 	src/Racing.hpp\
 	src/Vendors.hpp\
 	src/Trading.hpp\
+	src/Rand.hpp\
 
 COBJ=$(CSRC:.c=.o)
 CXXOBJ=$(CXXSRC:.cpp=.o)

--- a/config.ini
+++ b/config.ini
@@ -69,8 +69,6 @@ accountlevel=1
 # 2 = Halloween
 # 3 = Easter
 eventmode=0
-# percent chance of an event crate dropping each kill
-eventcratechance=10
 
 # you can override the default spawn point.
 # these example coords are for the Future (Z is height):

--- a/src/BuiltinCommands.cpp
+++ b/src/BuiltinCommands.cpp
@@ -4,6 +4,7 @@
 #include "Items.hpp"
 #include "Missions.hpp"
 #include "Nanos.hpp"
+#include "Rand.hpp"
 
 // helper function, not a packet handler
 void BuiltinCommands::setSpecialState(CNSocket* sock, CNPacketData* data) {
@@ -271,8 +272,8 @@ static void teleportPlayer(CNSocket *sock, CNPacketData *data) {
     case eCN_GM_TeleportMapType__Unstick:
         targetPlr = PlayerManager::getPlayer(targetSock);
 
-        PlayerManager::sendPlayerTo(targetSock, targetPlr->x - unstickRange/2 + rand() % unstickRange,
-            targetPlr->y - unstickRange/2 + rand() % unstickRange, targetPlr->z + 80);
+        PlayerManager::sendPlayerTo(targetSock, targetPlr->x - unstickRange/2 + Rand::rand(unstickRange),
+            targetPlr->y - unstickRange/2 + Rand::rand(unstickRange), targetPlr->z + 80);
         break;
     }
 }

--- a/src/Combat.cpp
+++ b/src/Combat.cpp
@@ -225,15 +225,12 @@ void Combat::killMob(CNSocket *sock, Mob *mob) {
     if (sock != nullptr) {
         Player* plr = PlayerManager::getPlayer(sock);
 
-        int rolledBoosts = Rand::rand();
-        int rolledPotions = Rand::rand();
-        int rolledCrate = Rand::rand();
-        int rolledCrateType = Rand::rand();
-        int rolledEvent = Rand::rand();
+        Items::DropRoll rolled;
+        Items::DropRoll eventRolled;
         int rolledQItem = Rand::rand();
 
         if (plr->groupCnt == 1 && plr->iIDGroup == plr->iID) {
-            Items::giveMobDrop(sock, mob, rolledBoosts, rolledPotions, rolledCrate, rolledCrateType, rolledEvent);
+            Items::giveMobDrop(sock, mob, rolled, eventRolled);
             Missions::mobKilled(sock, mob->appearanceData.iNPCType, rolledQItem);
         } else {
             Player* otherPlayer = PlayerManager::getPlayerFromID(plr->iIDGroup);
@@ -253,7 +250,7 @@ void Combat::killMob(CNSocket *sock, Mob *mob) {
                 if (dist > 5000)
                     continue;
 
-                Items::giveMobDrop(sockTo, mob, rolledBoosts, rolledPotions, rolledCrate, rolledCrateType, rolledEvent);
+                Items::giveMobDrop(sockTo, mob, rolled, eventRolled);
                 Missions::mobKilled(sockTo, mob->appearanceData.iNPCType, rolledQItem);
             }
         }

--- a/src/Items.cpp
+++ b/src/Items.cpp
@@ -566,25 +566,17 @@ static void chestOpenHandler(CNSocket *sock, CNPacketData *data) {
     int validCrateId = getValidCrateId(chest->iID);
     bool failing = (validCrateId == -1);
 
-    std::cout << "validCrateId " << validCrateId << std::endl;
-
     if (!failing)
         validItemSetId = getValidItemSetId(validCrateId);
     failing = (validItemSetId == -1);
-
-    std::cout << "validItemSetId " << validItemSetId << std::endl;
 
     if (!failing)
         rarity = getRarity(validCrateId, validItemSetId);
     failing = (rarity == -1);
 
-    std::cout << "rarity " << rarity << std::endl;
-
     if (!failing)
         ret = getCrateItem(&item->sItem, validItemSetId, rarity, plr->PCStyle.iGender);
     failing = (ret == -1);
-
-    std::cout << "ret " << ret << std::endl;
 
     // if we failed to open a crate, at least give the player a gumball (suggested by Jade)
     if (failing) {

--- a/src/Items.cpp
+++ b/src/Items.cpp
@@ -790,28 +790,28 @@ void Items::giveMobDrop(CNSocket *sock, Mob* mob, int rolledBoosts, int rolledPo
         std::cout << "[WARN] Crate Drop Chance Object " << drop.crateDropChanceId << " was not found" << std::endl;
         return;
     }
-    CrateDropChance crateDropChance = Items::CrateDropChances[drop.crateDropChanceId];
+    CrateDropChance& crateDropChance = Items::CrateDropChances[drop.crateDropChanceId];
 
     // sanity check
     if (Items::CrateDropTypes.find(drop.crateDropTypeId) == Items::CrateDropTypes.end()) {
         std::cout << "[WARN] Crate Drop Type Object " << drop.crateDropTypeId << " was not found" << std::endl;
         return;
     }
-    std::vector<int> crateDropType = Items::CrateDropTypes[drop.crateDropTypeId];
+    std::vector<int>& crateDropType = Items::CrateDropTypes[drop.crateDropTypeId];
 
     // sanity check
     if (Items::MiscDropChances.find(drop.miscDropChanceId) == Items::MiscDropChances.end()) {
         std::cout << "[WARN] Misc Drop Chance Object " << drop.miscDropChanceId << " was not found" << std::endl;
         return;
     }
-    MiscDropChance miscDropChance = Items::MiscDropChances[drop.miscDropChanceId];
+    MiscDropChance& miscDropChance = Items::MiscDropChances[drop.miscDropChanceId];
 
     // sanity check
     if (Items::MiscDropTypes.find(drop.miscDropTypeId) == Items::MiscDropTypes.end()) {
         std::cout << "[WARN] Misc Drop Type Object " << drop.miscDropTypeId << " was not found" << std::endl;
         return;
     }
-    MiscDropType miscDropType = Items::MiscDropTypes[drop.miscDropTypeId];
+    MiscDropType& miscDropType = Items::MiscDropTypes[drop.miscDropTypeId];
 
     plr->money += miscDropType.taroAmount;
     // money nano boost

--- a/src/Items.cpp
+++ b/src/Items.cpp
@@ -26,6 +26,7 @@ std::map<int32_t, std::vector<int32_t>> Items::CrateDropTypes;
 std::map<int32_t, MiscDropChance> Items::MiscDropChances;
 std::map<int32_t, MiscDropType> Items::MiscDropTypes;
 std::map<int32_t, MobDrop> Items::MobDrops;
+std::map<int32_t, int32_t> Items::MobToDropMap;
 std::map<int32_t, ItemSet> Items::ItemSets;
 
 #ifdef ACADEMY
@@ -770,12 +771,20 @@ void Items::giveMobDrop(CNSocket *sock, Mob* mob, int rolledBoosts, int rolledPo
     memset(respbuf, 0, resplen);
 
     // sanity check
-    if (MobDrops.find(mob->dropType) == MobDrops.end()) {
-        std::cout << "[WARN] Drop Type " << mob->dropType << " was not found" << std::endl;
+    if (Items::MobToDropMap.find(mob->appearanceData.iNPCType) == Items::MobToDropMap.end()) {
+        std::cout << "[WARN] Mob ID " << mob->appearanceData.iNPCType << " has no drops assigned" << std::endl;
+        return;
+    }
+    // find mob drop id
+    int dropType = Items::MobToDropMap[mob->appearanceData.iNPCType];
+
+    // sanity check
+    if (Items::MobDrops.find(dropType) == Items::MobDrops.end()) {
+        std::cout << "[WARN] Drop Type " << dropType << " was not found" << std::endl;
         return;
     }
     // find correct mob drop
-    MobDrop& drop = MobDrops[mob->dropType];
+    MobDrop& drop = Items::MobDrops[dropType];
 
     // use the keys to fetch data from other maps
     // sanity check

--- a/src/Items.cpp
+++ b/src/Items.cpp
@@ -138,7 +138,11 @@ static int getRarity(int crateId, int itemSetId) {
         relevantWeights.push_back(rarityWeights[index]);
 
     // now return a random rarity number (starting from 1)
-    return Rand::randWeighted(relevantWeights) + 1;
+    int rarityChoice = Rand::randWeighted(relevantWeights);
+
+    auto it = rarityIndices.begin();
+    std::advance(it, rarityChoice);
+    return *it + 1;
 }
 
 static int getCrateItem(sItemBase* result, int itemSetId, int rarity, int playerGender) {
@@ -562,17 +566,25 @@ static void chestOpenHandler(CNSocket *sock, CNPacketData *data) {
     int validCrateId = getValidCrateId(chest->iID);
     bool failing = (validCrateId == -1);
 
+    std::cout << "validCrateId " << validCrateId << std::endl;
+
     if (!failing)
         validItemSetId = getValidItemSetId(validCrateId);
     failing = (validItemSetId == -1);
+
+    std::cout << "validItemSetId " << validItemSetId << std::endl;
 
     if (!failing)
         rarity = getRarity(validCrateId, validItemSetId);
     failing = (rarity == -1);
 
+    std::cout << "rarity " << rarity << std::endl;
+
     if (!failing)
         ret = getCrateItem(&item->sItem, validItemSetId, rarity, plr->PCStyle.iGender);
     failing = (ret == -1);
+
+    std::cout << "ret " << ret << std::endl;
 
     // if we failed to open a crate, at least give the player a gumball (suggested by Jade)
     if (failing) {

--- a/src/Items.cpp
+++ b/src/Items.cpp
@@ -133,16 +133,15 @@ static int getRarity(int crateId, int itemSetId) {
         return -1;
     }
 
-    std::vector<int> relevantWeights;
-    for (int index : rarityIndices)
-        relevantWeights.push_back(rarityWeights[index]);
+    std::vector<int> relevantWeights(rarityWeights.size(), 0);
+    for (int index : rarityIndices) {
+        // sanity check
+        if (index >= 0 && index < rarityWeights.size())
+            relevantWeights[index] = rarityWeights[index];
+    }
 
     // now return a random rarity number (starting from 1)
-    int rarityChoice = Rand::randWeighted(relevantWeights);
-
-    auto it = rarityIndices.begin();
-    std::advance(it, rarityChoice);
-    return *it + 1;
+    return Rand::randWeighted(relevantWeights) + 1;
 }
 
 static int getCrateItem(sItemBase* result, int itemSetId, int rarity, int playerGender) {

--- a/src/Items.hpp
+++ b/src/Items.hpp
@@ -10,21 +10,51 @@ struct CrocPotEntry {
 };
 
 struct Crate {
-    int rarityRatioId;
-    std::vector<int> itemSets;
+    int itemSetChanceId;
+    int itemSetTypeId;
+    int rarityWeightId;
 };
 
-struct MobDropChance {
-    int dropChance;
-    std::vector<int> cratesRatio;
+struct CrateDropChance {
+    int dropChance, dropChanceTotal;
+    std::vector<int> crateWeights;
+};
+
+struct MiscDropChance {
+    int potionDropChance, potionDropChanceTotal;
+    int boostDropChance, boostDropChanceTotal;
+    int taroDropChance, taroDropChanceTotal;
+    int fmDropChance, fmDropChanceTotal;
+};
+
+struct MiscDropType {
+    int potionAmount;
+    int boostAmount;
+    int taroAmount;
+    int fmAmount;
 };
 
 struct MobDrop {
-    std::vector<int> crateIDs;
-    int dropChanceType;
-    int taros;
-    int fm;
-    int boosts;
+    int crateDropChanceId;
+    int crateDropTypeId;
+    int miscDropChanceId;
+    int miscDropTypeId;
+};
+
+struct ItemSetType {
+    bool ignoreGender;
+    std::vector<int> droppableItemIds;
+};
+
+struct ItemSetChance {
+    int defaultItemWeight;
+    std::map<int, int> specialItemWeights;
+};
+
+struct DroppableItem {
+    int itemId;
+    int rarity;
+    int type;
 };
 
 namespace Items {
@@ -44,16 +74,19 @@ namespace Items {
     // hopefully this is fine since it's never modified after load
     extern std::map<std::pair<int32_t, int32_t>, Item> ItemData; // <id, type> -> data
     extern std::map<int32_t, CrocPotEntry> CrocPotTable; // level gap -> entry
-    extern std::map<int32_t, std::vector<int>> RarityRatios;
+    extern std::map<int32_t, std::vector<int32_t>> RarityWeights;
     extern std::map<int32_t, Crate> Crates;
-    // pair <Itemset, Rarity> -> vector of pointers (map iterators) to records in ItemData (it looks a lot scarier than it is)
-    extern std::map<std::pair<int32_t, int32_t>,
-        std::vector<std::map<std::pair<int32_t, int32_t>, Item>::iterator>> CrateItems;
+    extern std::map<int32_t, DroppableItem> DroppableItems;
     extern std::map<std::string, std::vector<std::pair<int32_t, int32_t>>> CodeItems; // code -> vector of <id, type>
 
     // mob drops
-    extern std::map<int32_t, MobDropChance> MobDropChances;
+    extern std::map<int32_t, CrateDropChance> CrateDropChances;
+    extern std::map<int32_t, std::vector<int32_t>> CrateDropTypes;
+    extern std::map<int32_t, MiscDropChance> MiscDropChances;
+    extern std::map<int32_t, MiscDropType> MiscDropTypes;
     extern std::map<int32_t, MobDrop> MobDrops;
+    extern std::map<int32_t, ItemSetType> ItemSetTypes;
+    extern std::map<int32_t, ItemSetChance> ItemSetChances;
 
     void init();
 

--- a/src/Items.hpp
+++ b/src/Items.hpp
@@ -3,6 +3,7 @@
 #include "servers/CNShardServer.hpp"
 #include "Player.hpp"
 #include "MobAI.hpp"
+#include "Rand.hpp"
 
 struct CrocPotEntry {
     int multStats, multLooks;
@@ -80,6 +81,13 @@ namespace Items {
         int weaponType;
         // TODO: implement more as needed
     };
+    struct DropRoll {
+        int boosts, potions;
+        int taros, fm;
+        int crate, crateType;
+
+        DropRoll() : boosts(Rand::rand()), potions(Rand::rand()), taros(Rand::rand()), fm(Rand::rand()), crate(Rand::rand()), crateType(Rand::rand()) { }
+    };
     // hopefully this is fine since it's never modified after load
     extern std::map<std::pair<int32_t, int32_t>, Item> ItemData; // <id, type> -> data
     extern std::map<int32_t, CrocPotEntry> CrocPotTable; // level gap -> entry
@@ -94,13 +102,14 @@ namespace Items {
     extern std::map<int32_t, MiscDropChance> MiscDropChances;
     extern std::map<int32_t, MiscDropType> MiscDropTypes;
     extern std::map<int32_t, MobDrop> MobDrops;
+    extern std::map<int32_t, int32_t> EventToDropMap;
     extern std::map<int32_t, int32_t> MobToDropMap;
     extern std::map<int32_t, ItemSet> ItemSets;
 
     void init();
 
     // mob drops
-    void giveMobDrop(CNSocket *sock, Mob *mob, int rolledBoosts, int rolledPotions, int rolledCrate, int rolledCrateType, int rolledEvent);
+    void giveMobDrop(CNSocket *sock, Mob *mob, const DropRoll& rolled, const DropRoll& eventRolled);
 
     int findFreeSlot(Player *plr);
     Item* getItemData(int32_t id, int32_t type);

--- a/src/Items.hpp
+++ b/src/Items.hpp
@@ -17,7 +17,7 @@ struct Crate {
 
 struct CrateDropChance {
     int dropChance, dropChanceTotal;
-    std::vector<int> crateWeights;
+    std::vector<int> crateTypeDropWeights;
 };
 
 struct MiscDropChance {
@@ -43,18 +43,19 @@ struct MobDrop {
 
 struct ItemSetType {
     bool ignoreGender;
-    std::vector<int> droppableItemIds;
+    std::vector<int> itemReferenceIds;
 };
 
 struct ItemSetChance {
     int defaultItemWeight;
-    std::map<int, int> specialItemWeights;
+    std::map<int, int> indexWeightMap;
 };
 
-struct DroppableItem {
+struct ItemReference {
     int itemId;
-    int rarity;
     int type;
+    int rarity;
+    int gender;
 };
 
 namespace Items {
@@ -76,7 +77,7 @@ namespace Items {
     extern std::map<int32_t, CrocPotEntry> CrocPotTable; // level gap -> entry
     extern std::map<int32_t, std::vector<int32_t>> RarityWeights;
     extern std::map<int32_t, Crate> Crates;
-    extern std::map<int32_t, DroppableItem> DroppableItems;
+    extern std::map<int32_t, ItemReference> ItemReferences;
     extern std::map<std::string, std::vector<std::pair<int32_t, int32_t>>> CodeItems; // code -> vector of <id, type>
 
     // mob drops

--- a/src/Items.hpp
+++ b/src/Items.hpp
@@ -94,6 +94,7 @@ namespace Items {
     extern std::map<int32_t, MiscDropChance> MiscDropChances;
     extern std::map<int32_t, MiscDropType> MiscDropTypes;
     extern std::map<int32_t, MobDrop> MobDrops;
+    extern std::map<int32_t, int32_t> MobToDropMap;
     extern std::map<int32_t, ItemSet> ItemSets;
 
     void init();

--- a/src/Items.hpp
+++ b/src/Items.hpp
@@ -10,8 +10,7 @@ struct CrocPotEntry {
 };
 
 struct Crate {
-    int itemSetChanceId;
-    int itemSetTypeId;
+    int itemSetId;
     int rarityWeightId;
 };
 
@@ -41,14 +40,23 @@ struct MobDrop {
     int miscDropTypeId;
 };
 
-struct ItemSetType {
+struct ItemSet {
+    // itemset-wise offswitch to rarity filtering, every crate drops every rarity (still based on rarity weights)
+    bool ignoreRarity;
+    // itemset-wise offswitch for gender filtering, every crate can now drop neutral/boys/girls items
     bool ignoreGender;
-    std::vector<int> itemReferenceIds;
-};
-
-struct ItemSetChance {
+    // default weight of all items in the itemset
     int defaultItemWeight;
-    std::map<int, int> indexWeightMap;
+    // change the rarity class of items in the itemset here
+    // rarity 0 bypasses the rarity filter for an individual item
+    std::map<int, int> alterRarityMap;
+    // change the gender class of items in the itemset here
+    // gender 0 bypasses the gender filter for an individual item
+    std::map<int, int> alterGenderMap;
+    // change the item weghts items in the itemset here
+    // only taken into account for chosen rarity, and if the item isn't filtered away due to gender
+    std::map<int, int> alterItemWeightMap;
+    std::vector<int> itemReferenceIds;
 };
 
 struct ItemReference {
@@ -86,8 +94,7 @@ namespace Items {
     extern std::map<int32_t, MiscDropChance> MiscDropChances;
     extern std::map<int32_t, MiscDropType> MiscDropTypes;
     extern std::map<int32_t, MobDrop> MobDrops;
-    extern std::map<int32_t, ItemSetType> ItemSetTypes;
-    extern std::map<int32_t, ItemSetChance> ItemSetChances;
+    extern std::map<int32_t, ItemSet> ItemSets;
 
     void init();
 

--- a/src/MobAI.cpp
+++ b/src/MobAI.cpp
@@ -5,6 +5,7 @@
 #include "Nanos.hpp"
 #include "Combat.hpp"
 #include "Abilities.hpp"
+#include "Rand.hpp"
 
 #include <cmath>
 #include <limits.h>
@@ -334,7 +335,7 @@ static void useAbilities(Mob *mob, time_t currTime) {
         return;
     }
 
-    int random = rand() % 2000 * 1000;
+    int random = Rand::rand(2000) * 1000;
     int prob1 = (int)mob->data["m_iActiveSkill1Prob"]; // active skill probability
     int prob2 = (int)mob->data["m_iCorruptionTypeProb"]; // corruption probability
     int prob3 = (int)mob->data["m_iMegaTypeProb"]; // eruption probability
@@ -364,7 +365,7 @@ static void useAbilities(Mob *mob, time_t currTime) {
         if (mob->skillStyle == -1)
             mob->skillStyle = 2;
         if (mob->skillStyle == -2)
-            mob->skillStyle = rand() % 3;
+            mob->skillStyle = Rand::rand(3);
         pkt.iStyle = mob->skillStyle;
         NPCManager::sendToViewable(mob, &pkt, P_FE2CL_NPC_SKILL_CORRUPTION_READY, sizeof(sP_FE2CL_NPC_SKILL_CORRUPTION_READY));
         mob->nextAttack = currTime + 1800;
@@ -546,7 +547,7 @@ static void combatStep(Mob *mob, time_t currTime) {
             pkt1.iID = mob->appearanceData.iNPC_ID;
             pkt1.iConditionBitFlag = mob->appearanceData.iConditionBitFlag;
             NPCManager::sendToViewable(mob, &pkt1, P_FE2CL_CHAR_TIME_BUFF_TIME_OUT, sizeof(sP_FE2CL_CHAR_TIME_BUFF_TIME_OUT));
-                    
+
             it = mob->unbuffTimes.erase(it);
         } else {
             it++;
@@ -563,7 +564,7 @@ static void combatStep(Mob *mob, time_t currTime) {
     int mobRange = (int)mob->data["m_iAtkRange"] + (int)mob->data["m_iRadius"];
 
     if (currTime >= mob->nextAttack) {
-        if (mob->skillStyle != -1 || distance <= mobRange || rand() % 20 == 0) // while not in attack range, 1 / 20 chance.
+        if (mob->skillStyle != -1 || distance <= mobRange || Rand::rand(20) == 0) // while not in attack range, 1 / 20 chance.
             useAbilities(mob, currTime);
         if (mob->target == nullptr)
             return;
@@ -610,7 +611,7 @@ static void combatStep(Mob *mob, time_t currTime) {
         NPCManager::sendToViewable(mob, &pkt, P_FE2CL_NPC_MOVE, sizeof(sP_FE2CL_NPC_MOVE));
     }
 
-    /* attack logic 
+    /* attack logic
      * 2/5 represents 400 ms which is the time interval mobs use per movement logic step
      * if the mob is one move interval away, we should just start attacking anyways.
      */
@@ -638,7 +639,7 @@ void MobAI::incNextMovement(Mob *mob, time_t currTime) {
         currTime = getTime();
 
     int delay = (int)mob->data["m_iDelayTime"] * 1000;
-    mob->nextMovement = currTime + delay/2 + rand() % (delay/2);
+    mob->nextMovement = currTime + delay/2 + Rand::rand(delay/2);
 }
 
 static void roamingStep(Mob *mob, time_t currTime) {
@@ -681,8 +682,8 @@ static void roamingStep(Mob *mob, time_t currTime) {
     int minDistance = mob->idleRange / 2;
 
     // pick a random destination
-    farX = xStart + rand() % mob->idleRange;
-    farY = yStart + rand() % mob->idleRange;
+    farX = xStart + Rand::rand(mob->idleRange);
+    farY = yStart + Rand::rand(mob->idleRange);
 
     distance = std::abs(std::max(farX - mob->x, farY - mob->y));
     if (distance == 0)

--- a/src/MobAI.hpp
+++ b/src/MobAI.hpp
@@ -42,9 +42,6 @@ struct Mob : public CombatNPC {
     int skillStyle = -1; // -1 for nothing, 0-2 for corruption, -2 for eruption
     int hitX = 0, hitY = 0, hitZ = 0; // for use in ability targeting
 
-    // drop
-    int dropType = 0;
-
     // group
     int groupLeader = 0;
     int offsetX = 0, offsetY = 0;
@@ -65,7 +62,6 @@ struct Mob : public CombatNPC {
 
         regenTime = data["m_iRegenTime"];
         idleRange = (int)data["m_iIdleRange"];
-        dropType = data["m_iDropType"];
         level = data["m_iNpcLevel"];
 
         roamX = spawnX = x;

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -10,6 +10,7 @@
 #include "Racing.hpp"
 #include "Vendors.hpp"
 #include "Abilities.hpp"
+#include "Rand.hpp"
 
 #include <cmath>
 #include <algorithm>
@@ -104,7 +105,7 @@ static void npcBarkHandler(CNSocket* sock, CNPacketData* data) {
 
     INITSTRUCT(sP_FE2CL_REP_BARKER, resp);
     resp.iNPC_ID = req->iNPC_ID;
-    resp.iMissionStringID = barks[rand() % barks.size()];
+    resp.iMissionStringID = barks[Rand::rand(barks.size())];
     sock->sendPacket(resp, P_FE2CL_REP_BARKER);
 }
 

--- a/src/Rand.cpp
+++ b/src/Rand.cpp
@@ -1,0 +1,44 @@
+#include "Rand.hpp"
+
+#include <chrono>
+
+std::unique_ptr<std::mt19937> Rand::generator;
+
+int32_t Rand::rand(int32_t startInclusive, int32_t endExclusive) {
+    std::uniform_int_distribution<int32_t> dist(startInclusive, endExclusive - 1);
+    return dist(*Rand::generator);
+}
+
+int32_t Rand::rand(int32_t endExclusive) {
+    return Rand::rand(0, endExclusive);
+}
+
+int32_t Rand::rand() {
+    return Rand::rand(0, INT32_MAX);
+}
+
+int32_t Rand::randWeighted(const std::vector<int32_t>& weights) {
+    std::discrete_distribution<int32_t> dist(weights.begin(), weights.end());
+    return dist(*Rand::generator);
+}
+
+float Rand::randFloat(float startInclusive, float endExclusive) {
+    std::uniform_real_distribution<float> dist(startInclusive, endExclusive);
+    return dist(*Rand::generator);
+}
+
+float Rand::randFloat(float endExclusive) {
+    std::uniform_real_distribution<float> dist(0.0f, endExclusive);
+    return dist(*Rand::generator);
+}
+
+float Rand::randFloat() {
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    return dist(*Rand::generator);
+}
+
+void Rand::init() {
+    // modern equivalent of srand(time(0))
+    uint64_t seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    Rand::generator = std::make_unique<std::mt19937>(std::mt19937(seed));
+}

--- a/src/Rand.cpp
+++ b/src/Rand.cpp
@@ -1,7 +1,5 @@
 #include "Rand.hpp"
 
-#include <chrono>
-
 std::unique_ptr<std::mt19937> Rand::generator;
 
 int32_t Rand::rand(int32_t startInclusive, int32_t endExclusive) {
@@ -28,17 +26,13 @@ float Rand::randFloat(float startInclusive, float endExclusive) {
 }
 
 float Rand::randFloat(float endExclusive) {
-    std::uniform_real_distribution<float> dist(0.0f, endExclusive);
-    return dist(*Rand::generator);
+    return Rand::randFloat(0.0f, endExclusive);
 }
 
 float Rand::randFloat() {
-    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
-    return dist(*Rand::generator);
+    return Rand::randFloat(0.0f, 1.0f);
 }
 
-void Rand::init() {
-    // modern equivalent of srand(time(0))
-    uint64_t seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+void Rand::init(uint64_t seed) {
     Rand::generator = std::make_unique<std::mt19937>(std::mt19937(seed));
 }

--- a/src/Rand.hpp
+++ b/src/Rand.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <random>
+#include <memory>
+
+namespace Rand {
+    extern std::unique_ptr<std::mt19937> generator;
+
+    void init();
+
+    int32_t rand(int32_t startInclusive, int32_t endExclusive);
+    int32_t rand(int32_t endExclusive);
+    int32_t rand();
+
+    int32_t randWeighted(const std::vector<int32_t>& weights);
+
+    float randFloat(float startInclusive, float endExclusive);
+    float randFloat(float endExclusive);
+    float randFloat();
+};

--- a/src/Rand.hpp
+++ b/src/Rand.hpp
@@ -6,7 +6,7 @@
 namespace Rand {
     extern std::unique_ptr<std::mt19937> generator;
 
-    void init();
+    void init(uint64_t seed);
 
     int32_t rand(int32_t startInclusive, int32_t endExclusive);
     int32_t rand(int32_t endExclusive);

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -274,6 +274,14 @@ static void loadDrops() {
             };
         }
 
+        // Events
+        nlohmann::json events = dropData["Events"];
+        for (nlohmann::json::iterator _event = events.begin(); _event != events.end(); _event++) {
+            auto event = _event.value();
+
+            Items::EventToDropMap[(int)event["EventID"]] = (int)event["MobDropID"];
+        }
+
         // Mobs
         nlohmann::json mobs = dropData["Mobs"];
         for (nlohmann::json::iterator _mob = mobs.begin(); _mob != mobs.end(); _mob++) {

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -287,34 +287,33 @@ static void loadDrops() {
             Items::RarityWeights[(int)rarityWeightsObject["RarityWeightID"]] = toAdd;
         }
 
-        // ItemSetTypes
-        nlohmann::json itemSetTypes = dropData["ItemSetTypes"];
-        for (nlohmann::json::iterator _itemSetType = itemSetTypes.begin(); _itemSetType != itemSetTypes.end(); _itemSetType++) {
-            auto itemSetType = _itemSetType.value();
-            ItemSetType toAdd = {};
+        // ItemSets
+        nlohmann::json itemSets = dropData["ItemSets"];
+        for (nlohmann::json::iterator _itemSet = itemSets.begin(); _itemSet != itemSets.end(); _itemSet++) {
+            auto itemSet = _itemSet.value();
+            ItemSet toAdd = {};
 
-            toAdd.ignoreGender = (bool)itemSetType["IgnoreGender"];
+            toAdd.ignoreRarity = (bool)itemSet["IgnoreRarity"];
+            toAdd.ignoreGender = (bool)itemSet["IgnoreGender"];
+            toAdd.defaultItemWeight = (int)itemSet["DefaultItemWeight"];
 
-            nlohmann::json itemReferenceIds = itemSetType["ItemReferenceIDs"];
+            nlohmann::json alterRarityMap = itemSet["AlterRarityMap"];
+            for (nlohmann::json::iterator _alterRarityMapEntry = alterRarityMap.begin(); _alterRarityMapEntry != alterRarityMap.end(); _alterRarityMapEntry++)
+                toAdd.alterRarityMap[std::atoi(_alterRarityMapEntry.key().c_str())] = (int)_alterRarityMapEntry.value();
+
+            nlohmann::json alterGenderMap = itemSet["AlterGenderMap"];
+            for (nlohmann::json::iterator _alterGenderMapEntry = alterGenderMap.begin(); _alterGenderMapEntry != alterGenderMap.end(); _alterGenderMapEntry++)
+                toAdd.alterGenderMap[std::atoi(_alterGenderMapEntry.key().c_str())] = (int)_alterGenderMapEntry.value();
+
+            nlohmann::json alterItemWeightMap = itemSet["AlterItemWeightMap"];
+            for (nlohmann::json::iterator _alterItemWeightMapEntry = alterItemWeightMap.begin(); _alterItemWeightMapEntry != alterItemWeightMap.end(); _alterItemWeightMapEntry++)
+                toAdd.alterItemWeightMap[std::atoi(_alterItemWeightMapEntry.key().c_str())] = (int)_alterItemWeightMapEntry.value();
+
+            nlohmann::json itemReferenceIds = itemSet["ItemReferenceIDs"];
             for (nlohmann::json::iterator itemReferenceId = itemReferenceIds.begin(); itemReferenceId != itemReferenceIds.end(); itemReferenceId++)
                 toAdd.itemReferenceIds.push_back((int)itemReferenceId.value());
 
-            Items::ItemSetTypes[(int)itemSetType["ItemSetTypeID"]] = toAdd;
-        }
-
-        // ItemSetChances
-        nlohmann::json itemSetChances = dropData["ItemSetChances"];
-        for (nlohmann::json::iterator _itemSetChanceObject = itemSetChances.begin(); _itemSetChanceObject != itemSetChances.end(); _itemSetChanceObject++) {
-            auto itemSetChanceObject = _itemSetChanceObject.value();
-            ItemSetChance toAdd = {};
-
-            toAdd.defaultItemWeight = (int)itemSetChanceObject["DefaultItemWeight"];
-
-            nlohmann::json indexWeightMap = itemSetChanceObject["IndexWeightMap"];
-            for (nlohmann::json::iterator _indexWeightMapEntry = indexWeightMap.begin(); _indexWeightMapEntry != indexWeightMap.end(); _indexWeightMapEntry++)
-                toAdd.indexWeightMap[std::atoi(_indexWeightMapEntry.key().c_str())] = (int)_indexWeightMapEntry.value();
-
-            Items::ItemSetChances[(int)itemSetChanceObject["ItemSetChanceID"]] = toAdd;
+            Items::ItemSets[(int)itemSet["ItemSetID"]] = toAdd;
         }
 
         // Crates
@@ -323,8 +322,7 @@ static void loadDrops() {
             auto crate = _crate.value();
 
             Items::Crates[(int)crate["CrateID"]] = {
-                (int)crate["ItemSetChanceID"],
-                (int)crate["ItemSetTypeID"],
+                (int)crate["ItemSetID"],
                 (int)crate["RarityWeightID"]
             };
         }

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -274,6 +274,14 @@ static void loadDrops() {
             };
         }
 
+        // Mobs
+        nlohmann::json mobs = dropData["Mobs"];
+        for (nlohmann::json::iterator _mob = mobs.begin(); _mob != mobs.end(); _mob++) {
+            auto mob = _mob.value();
+
+            Items::MobToDropMap[(int)mob["MobID"]] = (int)mob["MobDropID"];
+        }
+
         // RarityWeights
         nlohmann::json rarityWeights = dropData["RarityWeights"];
         for (nlohmann::json::iterator _rarityWeightsObject = rarityWeights.begin(); _rarityWeightsObject != rarityWeights.end(); _rarityWeightsObject++) {

--- a/src/Vendors.cpp
+++ b/src/Vendors.cpp
@@ -1,4 +1,5 @@
 #include "Vendors.hpp"
+#include "Rand.hpp"
 
 using namespace Vendors;
 
@@ -328,7 +329,7 @@ static void vendorCombineItems(CNSocket* sock, CNPacketData* data) {
         break;
     }
 
-    float rolled = (rand() * 1.0f / RAND_MAX) * 100.0f; // success chance out of 100
+    float rolled = Rand::randFloat(100.0f); // success chance out of 100
     //std::cout << rolled << " vs " << successChance << std::endl;
     plr->money -= cost;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
 #else
     initsignals();
 #endif
-    Rand::init();
+    Rand::init(getTime());
     settings::init();
     std::cout << "[INFO] OpenFusion v" GIT_VERSION << std::endl;
     std::cout << "[INFO] Protocol version: " << PROTOCOL_VERSION << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "Vendors.hpp"
 #include "Chat.hpp"
 #include "Eggs.hpp"
+#include "Rand.hpp"
 
 #include "settings.hpp"
 
@@ -56,7 +57,7 @@ void terminate(int arg) {
 
     if (shardServer != nullptr && shardThread != nullptr)
         shardServer->kill();
-    
+
     Database::close();
     exit(0);
 }
@@ -93,7 +94,7 @@ int main() {
 #else
     initsignals();
 #endif
-    srand(getTime());
+    Rand::init();
     settings::init();
     std::cout << "[INFO] OpenFusion v" GIT_VERSION << std::endl;
     std::cout << "[INFO] Protocol version: " << PROTOCOL_VERSION << std::endl;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -60,7 +60,6 @@ int settings::MONITORINTERVAL = 5000;
 
 // event mode settings
 int settings::EVENTMODE = 0;
-int settings::EVENTCRATECHANCE = 10;
 
 void settings::init() {
     INIReader reader("config.ini");
@@ -99,7 +98,6 @@ void settings::init() {
     DBPATH = reader.Get("shard", "dbpath", DBPATH);
     ACCLEVEL = reader.GetInteger("shard", "accountlevel", ACCLEVEL);
     EVENTMODE = reader.GetInteger("shard", "eventmode", EVENTMODE);
-    EVENTCRATECHANCE = reader.GetInteger("shard", "eventcratechance", EVENTCRATECHANCE);
     DISABLEFIRSTUSEFLAG = reader.GetBoolean("shard", "disablefirstuseflag", DISABLEFIRSTUSEFLAG);
     MONITORENABLED = reader.GetBoolean("monitor", "enabled", MONITORENABLED);
     MONITORPORT = reader.GetInteger("monitor", "port", MONITORPORT);

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -26,7 +26,6 @@ namespace settings {
     extern std::string GRUNTWORKJSON;
     extern std::string DBPATH;
     extern int EVENTMODE;
-    extern int EVENTCRATECHANCE;
     extern bool MONITORENABLED;
     extern int MONITORPORT;
     extern int MONITORINTERVAL;


### PR DESCRIPTION
The new `drops.json` format:
![OF Drops Modified Format 2021](https://imgur.com/AK0HvUA.png)

This PR does the following:
- Allows for C.R.A.T.E.s, Weapon Boosts, Potions, Taros, FM and items to drop with (almost) arbitrary probabilities. 
- Makes it possible to add weights to items, so that even for the same itemset and rarity, the item selection doesn't have to be made uniform. The weights are specified in an index-based fashion, where we only specify the weights that do not conform to the default uniform distribution of weights over all items.
- Creates the minimum number of "merged" itemsets so that we never have to refer to multiple itemsets per C.R.A.T.E. 
- Avoids multiple entries per item by introducing a new id. 
- Allows itemsets to bypass the gender filter.
- Allows for random number generation up to `INT32_MAX - 1`, allowing for the new and improved probability system to work properly with extreme odds (Please use `Rand::rand()` instead of `rand()` once this is merged).
- Allows random weighted index selection.

**Important Note**: https://github.com/OpenFusionProject/tabledata/pull/11 needs to be merged before this.

**Side Note 1**: [This script](https://gist.github.com/FinnHornhoover/d43491c98fa6b301998b13bc7c50b653) was used to transform the old format to this format.

**Side Note 2**: [This script](https://gist.github.com/FinnHornhoover/5312b60a1e57ed6087850bc8bb90e5c1) can turn a JSON formatted with the new format into an XLSX file, and vice-versa. It is not final, and will probably be revised to make things easier on us until we have a GUI to edit the new format.