### PR TITLE
Include emails in chat dump

### DIFF
--- a/src/Email.cpp
+++ b/src/Email.cpp
@@ -226,10 +226,10 @@ static void emailSend(CNSocket* sock, CNPacketData* data) {
 
     INITSTRUCT(sP_FE2CL_REP_PC_SEND_EMAIL_SUCC, resp);
 
+    Player otherPlr = {};
+    Database::getPlayer(&otherPlr, pkt->iTo_PCUID);
     if (pkt->iCash || pkt->aItem[0].ItemInven.iID) {
         // if there are item or taro attachments
-        Player otherPlr = {};
-        Database::getPlayer(&otherPlr, pkt->iTo_PCUID);
         if (otherPlr.iID != 0 && plr->PCStyle2.iPayzoneFlag != otherPlr.PCStyle2.iPayzoneFlag) {
             // if the players are not in the same time period
             INITSTRUCT(sP_FE2CL_REP_PC_SEND_EMAIL_FAIL, resp);
@@ -304,6 +304,10 @@ static void emailSend(CNSocket* sock, CNPacketData* data) {
     resp.iTo_PCUID = pkt->iTo_PCUID;
 
     sock->sendPacket(resp, P_FE2CL_REP_PC_SEND_EMAIL_SUCC);
+
+    std::string logEmail = "[Email] " + PlayerManager::getPlayerName(plr, true) + " (to " + PlayerManager::getPlayerName(&otherPlr, true) + "): <" + email.SubjectLine + ">\n" + email.MsgBody;
+    std::cout << logEmail << std::endl;
+    Chat::dump.push_back(logEmail);
 }
 
 void Email::init() {


### PR DESCRIPTION
Emails are not currently being logged so they can't be easily monitored for moderation purposes.
This PR leverages the existing chat dump attached to the server monitor and pushes email strings into the same array.
The email string consists of the subject line in arrow braces <> followed by every sanitized line of the message body.
![1](https://user-images.githubusercontent.com/5123173/138208323-db14d289-5fec-47ff-b0d2-864ad17f8d10.png)
![2](https://user-images.githubusercontent.com/5123173/138208330-3bbc1ef8-b54b-40c1-a09f-848f973a5f78.png)


