### PR TITLE
Add CI/CD step to upload artifacts off-site

### DIFF
--- a/.github/workflows/check-builds.yaml
+++ b/.github/workflows/check-builds.yaml
@@ -13,6 +13,9 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set environment
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+        shell: bash
       - uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -42,12 +45,15 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: 'ubuntu20_04-bin-x64-${{ github.sha }}'
+          name: 'ubuntu20_04-bin-x64-${{ env.SHORT_SHA }}'
           path: bin
 
   windows-build:
     runs-on: windows-2019
     steps:
+      - name: Set environment
+        run: $s = $env:GITHUB_SHA.subString(0, 7); echo "SHORT_SHA=$s" >> $env:GITHUB_ENV
+        shell: pwsh
       - uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -92,7 +98,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: 'windows-vs2019-bin-x64-${{ github.sha }}'
+          name: 'windows-vs2019-bin-x64-${{ env.SHORT_SHA }}'
           path: bin
 
   copy-artifacts:

--- a/.github/workflows/check-builds.yaml
+++ b/.github/workflows/check-builds.yaml
@@ -96,6 +96,7 @@ jobs:
           path: bin
 
   copy-artifacts:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [windows-build, ubuntu-build]
     env:

--- a/.github/workflows/check-builds.yaml
+++ b/.github/workflows/check-builds.yaml
@@ -94,3 +94,12 @@ jobs:
         with:
           name: windows-vs2019-bin-x64
           path: bin
+
+  copy-artifacts:
+    runs-on: ubuntu-latest
+    needs: [windows-build, ubuntu-build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+      - name: Upload artifacts
+        run: ls -al

--- a/.github/workflows/check-builds.yaml
+++ b/.github/workflows/check-builds.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ubuntu20_04-bin-x64-$GITHUB_SHA.zip
+          name: 'ubuntu20_04-bin-x64-${{ github.sha }}'
           path: bin
 
   windows-build:
@@ -92,14 +92,22 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: windows-vs2019-bin-x64-$GITHUB_SHA.zip
+          name: 'windows-vs2019-bin-x64-${{ github.sha }}'
           path: bin
 
   copy-artifacts:
     runs-on: ubuntu-latest
     needs: [windows-build, ubuntu-build]
+    env:
+      BOT_SSH_KEY: ${{ secrets.BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - run: mkdir ${{ github.sha }}
       - uses: actions/download-artifact@v3
+        with:
+          path: ${{ github.sha }}
       - name: Upload artifacts
-        run: ls -al
+        shell: bash
+        run: |
+          umask 077
+          printf %s "$BOT_SSH_KEY" > cdn_key
+          scp -i cdn_key -o StrictHostKeyChecking=no -r ${{ github.sha }} gsemaj@gentasaur.us:~/

--- a/.github/workflows/check-builds.yaml
+++ b/.github/workflows/check-builds.yaml
@@ -107,6 +107,18 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: ${{ github.sha }}
+      - name: Prepare artifacts
+        shell: bash
+        run: |
+          sudo apt install zip -y
+          cd ${{ github.sha }}
+          for build in *; do
+            cd $build
+            zip ../$build.zip *
+            cd ..
+            rm -r $build
+          done
+          cd ..
       - name: Upload artifacts
         shell: bash
         run: |

--- a/.github/workflows/check-builds.yaml
+++ b/.github/workflows/check-builds.yaml
@@ -100,7 +100,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [windows-build, ubuntu-build]
     env:
-      BOT_SSH_KEY: ${{ secrets.BOT_TOKEN }}
+      BOT_SSH_KEY: ${{ secrets.BOT_SSH_KEY }}
+      ENDPOINT: ${{ secrets.ENDPOINT }}
     steps:
       - run: mkdir ${{ github.sha }}
       - uses: actions/download-artifact@v3
@@ -111,4 +112,4 @@ jobs:
         run: |
           umask 077
           printf %s "$BOT_SSH_KEY" > cdn_key
-          scp -i cdn_key -o StrictHostKeyChecking=no -r ${{ github.sha }} gsemaj@gentasaur.us:~/
+          scp -i cdn_key -o StrictHostKeyChecking=no -r ${{ github.sha }} $ENDPOINT

--- a/.github/workflows/check-builds.yaml
+++ b/.github/workflows/check-builds.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ubuntu20_04-bin-x64
+          name: ubuntu20_04-bin-x64-$GITHUB_SHA.zip
           path: bin
 
   windows-build:
@@ -92,7 +92,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: windows-vs2019-bin-x64
+          name: windows-vs2019-bin-x64-$GITHUB_SHA.zip
           path: bin
 
   copy-artifacts:


### PR DESCRIPTION
Non-PR pushes now trigger a job to compress and SCP artifacts to a predefined endpoint.
Secrets that need to be added before this works:
- `BOT_SSH_KEY`: private SSH key to access endpoint
- `ENDPOINT`: full path to destination e.g. `user@host:/tmp/...`