### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:latest
+
+WORKDIR /usr/src/app
+
+RUN apt-get -y update && apt-get install -y \
+git \
+clang \
+make \
+libsqlite3-dev
+
+COPY . ./
+
+RUN make -j8
+
+# tabledata should be copied from the host;
+# clone it there before building the container
+#RUN git submodule update --init --recursive
+
+CMD ["./bin/fusion"]
+
+LABEL Name=openfusion Version=0.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.4'
+
+services:
+  openfusion:
+    image: openfusion
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - "23000:23000"
+      - "23001:23001"
+      - "8003:8003"


### PR DESCRIPTION
Got bored so I wrote up a simple Dockerfile and docker-compose for anyone who wants to run the server in a container.
The config and tabledata are copied from the host, so you can customize the instance as usual.
The docler-compose maps the default ports automatically.
**Important:** seccomp-bpf does not play nice. The container will crash if it's enabled so it needs to be disabled before building.