### PR TITLE
Option to disable score capping for IZ Races

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -66,6 +66,9 @@ motd=Welcome to OpenFusion!
 # location of the database
 #dbpath=database.db
 
+# should there be a score cap for infected zone races?
+#izracescorecapped=true
+
 # should tutorial flags be disabled off the bat?
 disablefirstuseflag=true
 

--- a/src/Racing.cpp
+++ b/src/Racing.cpp
@@ -106,10 +106,11 @@ static void racingEnd(CNSocket* sock, CNPacketData* data) {
     int timeDiff = now - epRace.startTime;
     int podsCollected = epRace.collectedRings.size();
 
-    int score = std::min(epInfo.maxScore, (int)std::exp(
+    int score = std::exp(
         (epInfo.podFactor * podsCollected) / epInfo.maxPods
         - (epInfo.timeFactor * timeDiff) / epInfo.maxTime
-        + epInfo.scaleFactor));
+        + epInfo.scaleFactor);
+    score = (settings::IZRACESCORECAPPED && score > epInfo.maxScore) ? epInfo.maxScore : score;
     int fm = (1.0 + std::exp(epInfo.scaleFactor - 1.0) * epInfo.podFactor * podsCollected) / epInfo.maxPods;
 
     // we submit the ranking first...

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -67,6 +67,9 @@ int settings::MONITORINTERVAL = 5000;
 // event mode settings
 int settings::EVENTMODE = 0;
 
+// race settings
+bool settings::IZRACESCORECAPPED = true;
+
 void settings::init() {
     INIReader reader("config.ini");
 
@@ -111,6 +114,7 @@ void settings::init() {
     EVENTMODE = reader.GetInteger("shard", "eventmode", EVENTMODE);
     DISABLEFIRSTUSEFLAG = reader.GetBoolean("shard", "disablefirstuseflag", DISABLEFIRSTUSEFLAG);
     ANTICHEAT = reader.GetBoolean("shard", "anticheat", ANTICHEAT);
+    IZRACESCORECAPPED = reader.GetBoolean("shard", "izracescorecapped", IZRACESCORECAPPED);
     MONITORENABLED = reader.GetBoolean("monitor", "enabled", MONITORENABLED);
     MONITORPORT = reader.GetInteger("monitor", "port", MONITORPORT);
     MONITORINTERVAL = reader.GetInteger("monitor", "interval", MONITORINTERVAL);

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -38,6 +38,7 @@ namespace settings {
     extern int MONITORPORT;
     extern int MONITORINTERVAL;
     extern bool DISABLEFIRSTUSEFLAG;
+    extern bool IZRACESCORECAPPED;
 
     void init();
 }


### PR DESCRIPTION
While the original game behavior is to use the maximum scores of each IZ to cap the race scores, this might be undesirable now for servers with competitive players. 

A configuration option is added to disable score capping, removing the need for the server owner to set high maximum scores in `drops.json` manually.