### PR TITLE
Rank Calculation Out-of-Bounds Fix

### DIFF
--- a/src/Racing.cpp
+++ b/src/Racing.cpp
@@ -133,8 +133,9 @@ static void racingEnd(CNSocket* sock, CNPacketData* data) {
     std::vector<int>* rankRewards = &EPRewards[epInfo.EPID].second;
 
     // top ranking
+    int maxRank = rankScores->size() - 1;
     int topRank = 0;
-    while (rankScores->at(topRank) > topRankingPlayer.Score)
+    while (topRank < maxRank && rankScores->at(topRank) > topRankingPlayer.Score)
         topRank++;
 
     resp.iEPTopRank = topRank + 1;
@@ -144,7 +145,7 @@ static void racingEnd(CNSocket* sock, CNPacketData* data) {
 
     // this ranking
     int rank = 0;
-    while (rankScores->at(rank) > postRanking.Score)
+    while (rank < maxRank && rankScores->at(rank) > postRanking.Score)
         rank++;
 
     resp.iEPRank = rank + 1;


### PR DESCRIPTION
In PR #257 and the related tabledata PR https://github.com/OpenFusionProject/tabledata/pull/19, rank scores were replaced, but the old scores always had a value of 0 at the last rank. This had the effect of a null terminator and rank calculation never went out of bounds. When this pattern was broken, 0 star races were able to crash the server.

There's now an explicit bounds check that prevents this.