### PR TITLE
Fix a few compiler warnings and formatting for DB startup message

### DIFF
--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -610,7 +610,7 @@ static void loadDrops(json& dropData) {
 
             if (rankScores.size() != 5 || rankScores.size() != rankRewards.size()) {
                 char buff[255];
-                sprintf(buff, "Race in EP %d doesn't have exactly 5 score/reward pairs", raceEPID);
+                snprintf(buff, 255, "Race in EP %d doesn't have exactly 5 score/reward pairs", raceEPID);
                 throw TableException(std::string(buff));
             }
 

--- a/src/db/init.cpp
+++ b/src/db/init.cpp
@@ -267,17 +267,17 @@ void Database::open() {
     checkMetaTable();
     createTables();
 
-    std::cout << "[INFO] Database in operation ";
+    std::cout << "[INFO] Database in operation";
     int accounts = getTableSize("Accounts");
     int players = getTableSize("Players");
     std::string message = "";
     if (accounts > 0) {
-        message += ": Found " + std::to_string(accounts) + " account(s)";
+        message += ": Found " + std::to_string(accounts) + " account";
         if (accounts > 1)
             message += "s";
     }
     if (players > 0) {
-        message += " and " + std::to_string(players) + " player(s)";
+        message += " and " + std::to_string(players) + " player";
         if (players > 1)
             message += "s";
     }

--- a/vendor/bcrypt/bcrypt.c
+++ b/vendor/bcrypt/bcrypt.c
@@ -22,9 +22,13 @@
 #endif
 #include <errno.h>
 
-#ifdef _WIN32 || _WIN64
+#if defined(_WIN32) || defined(_WIN64)
 // On windows we need to generate random bytes differently.
+#if defined(_WIN32) && !defined(_WIN64)
+typedef __int32 ssize_t;
+#elif defined(_WIN32) && defined(_WIN64)
 typedef __int64 ssize_t;
+#endif
 #define BCRYPT_HASHSIZE 60
 
 #include "bcrypt.h"
@@ -117,7 +121,7 @@ int bcrypt_gensalt(int factor, char salt[BCRYPT_HASHSIZE])
 	char *aux;
 
 	// Note: Windows does not have /dev/urandom sadly.
-#ifdef _WIN32 || _WIN64
+#if defined(_WIN32) || defined(_WIN64)
 	HCRYPTPROV p;
 	ULONG     i;
 

--- a/vendor/bcrypt/crypt_blowfish.c
+++ b/vendor/bcrypt/crypt_blowfish.c
@@ -51,7 +51,7 @@
 #endif
 
 /* Just to make sure the prototypes match the actual definitions */
-#ifdef _WIN32 || _WIN64
+#if defined(_WIN32) || defined(_WIN64)
 #include "crypt_blowfish.h"
 #else
 #include "crypt_blowfish.h"

--- a/vendor/bcrypt/wrapper.c
+++ b/vendor/bcrypt/wrapper.c
@@ -41,7 +41,7 @@
 #define __SKIP_GNU
 #endif
 
-#ifdef _WIN32 | _WIN64
+#if defined(_WIN32) || defined(_WIN64)
 #include "ow-crypt.h"
 
 #include "crypt_blowfish.h"
@@ -251,7 +251,7 @@ char *__crypt_gensalt_ra(const char *prefix, unsigned long count,
 		input, size, output, sizeof(output));
 
 	if (retval) {
-#ifdef _WIN32 | _WIN64
+#if defined(_WIN32) || defined(_WIN64)
 		retval = _strdup(retval);
 #else
 		retval = strdup(retval);


### PR DESCRIPTION
Note that the warning in TableData.cpp only seems to occur on clang (deprecated-declarations)

Database account/player count message:
Before: `[INFO] Database in operation : Found 1 account(s) and 2 player(s)s` 
After: `[INFO] Database in operation: Found 1 account and 2 players`