### PR TITLE
Docker QOL Improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-version.h

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
+    volumes:
+      - ./config.ini:/usr/src/app/config.ini
+      - ./database.db:/usr/src/app/config.ini
+      - ./tdata:/usr/src/app/tdata
     ports:
       - "23000:23000"
       - "23001:23001"


### PR DESCRIPTION
- Use a separate build stage for compilation so that build dependencies don't get included in the final image
- Only copy files required for build into the build stage (fixes issue w compiler output getting copied from host machine)
- Mount tabledata, database, and config from the host