### PR TITLE
CD - Add GitHub Action to push Docker image to Docker Hub

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,0 +1,32 @@
+name: Push Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push-docker-image:
+    name: Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Retrieve major version
+        uses: winterjung/split@v2
+        id: split
+        with:
+          msg: ${{ github.ref_name }}
+          separator: .
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_REPOSITORY }}:${{ github.ref_name }},${{ secrets.DOCKERHUB_REPOSITORY }}:${{ steps.split.outputs._0 }},${{ secrets.DOCKERHUB_REPOSITORY }}:latest

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      matrix:
+        platforms:
+          - linux/amd64
+          - linux/arm64
     steps:
       - uses: actions/checkout@v4
       - name: Retrieve major version
@@ -28,5 +33,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: ${{ matrix.platforms }}
           push: true
           tags: ${{ secrets.DOCKERHUB_REPOSITORY }}:${{ github.ref_name }},${{ secrets.DOCKERHUB_REPOSITORY }}:${{ steps.split.outputs._0 }},${{ secrets.DOCKERHUB_REPOSITORY }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build
-FROM debian:latest as build
+FROM debian:stable-slim as build
 
 WORKDIR /usr/src/app
 
@@ -17,7 +17,7 @@ COPY Makefile CMakeLists.txt version.h.in ./
 RUN make -j8
 
 # prod
-FROM debian:latest
+FROM debian:stable-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Add a GitHub Action to automatically push an official Docker image of OpenFusion server to Docker Hub every time a new release is published.

The following secrets are necessary:

- `DOCKERHUB_TOKEN` - A Docker Hub token with write permissions
- `DOCKERHUB_USERNAME` - The user of Docker Hub who will be pushing the Docker image
- `DOCKERHUB_REPOSITORY` - The Docker Hub repository where the Docker image will be pushed to