### PR TITLE
BUILD - Optimize Dockerfile by using alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN make -j8
 # prod
 FROM alpine:3
 
+ENV AUTHENTICATION_PORT 23000
+ENV MONITORING_PORT 8003
+ENV SHARDING_PORT 23001
+
 WORKDIR /usr/src/app
 
 RUN apk update && apk upgrade && apk add \
@@ -31,6 +35,10 @@ sqlite-dev
 
 COPY --from=build /usr/src/app/bin/fusion /bin/fusion
 COPY sql ./sql
+
+EXPOSE $AUTHENTICATION_PORT
+EXPOSE $MONITORING_PORT
+EXPOSE $SHARDING_PORT
 
 CMD ["/bin/fusion"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,33 @@
 # build
-FROM debian:stable-slim as build
+FROM alpine:3 as build
 
 WORKDIR /usr/src/app
 
-RUN apt-get -y update && apt-get install -y \
+RUN apk update && apk upgrade && apk add \
+linux-headers \
 git \
-clang \
+clang18 \
 make \
-libsqlite3-dev
+sqlite-dev
 
 COPY src ./src
 COPY vendor ./vendor
 COPY .git ./.git
 COPY Makefile CMakeLists.txt version.h.in ./
 
+RUN sed -i 's/^CC=clang$/&-18/' Makefile
+RUN sed -i 's/^CXX=clang++$/&-18/' Makefile
+
 RUN make -j8
 
 # prod
-FROM debian:stable-slim
+FROM alpine:3
 
 WORKDIR /usr/src/app
 
-RUN apt-get -y update && apt-get install -y \
-libsqlite3-dev
+RUN apk update && apk upgrade && apk add \
+libstdc++ \
+sqlite-dev
 
 COPY --from=build /usr/src/app/bin/fusion /bin/fusion
 COPY sql ./sql

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdint.h>
 #include <string>
 
 namespace settings {
@@ -13,7 +14,7 @@ namespace settings {
     extern std::string SHARDSERVERIP;
     extern bool LOCALHOSTWORKAROUND;
     extern bool ANTICHEAT;
-    extern time_t TIMEOUT;
+    extern int64_t TIMEOUT;
     extern int VIEWDISTANCE;
     extern bool SIMULATEMOBS;
     extern int SPAWN_X;


### PR DESCRIPTION
Optimized Dockerfile by using `alpine:3` as base image for **build** and **prod** stages.

## Why is this PR opened as a draft PR?

This is because I talked with @dongresource, and he mentioned that you guys must be sure that changing the datatype of property `TIMEOUT` from `src/settings.hpp` to `int64_t` works and doesn't break anything while running the server application.

This is a PR mainly intended for allowing you all to know by first hand what is necessary for making the optimizations to Dockerfile.

By the way, the changes made to file `src/settings.hpp` were extracted from the branch `win32-x86`.