### PR TITLE
Immediate email notifications

### DIFF
--- a/src/Email.cpp
+++ b/src/Email.cpp
@@ -325,6 +325,13 @@ static void emailSend(CNSocket* sock, CNPacketData* data) {
     std::string logEmail = "[Email] " + PlayerManager::getPlayerName(plr, true) + " (to " + PlayerManager::getPlayerName(&otherPlr, true) + "): <" + email.SubjectLine + ">\n" + email.MsgBody;
     std::cout << logEmail << std::endl;
     dump.push_back(logEmail);
+
+    // notification to recipient if online
+    CNSocket* recipient = PlayerManager::getSockFromID(pkt->iTo_PCUID);
+    if (recipient != nullptr)
+    {
+        emailUpdateCheck(recipient, nullptr);
+    }
 }
 
 void Email::init() {


### PR DESCRIPTION
The current email notification behavior is a bit confusing (see #251) as one would expect to get a new email notification immediately upon receiving one. Instead, we wait until the client asks for an email update check, which could be up to 10 minutes without notifications.

This tiny change sends a notification to the recipient immediately if they are online.