### PR TITLE
Enable account level changing at runtime

### DIFF
--- a/src/CustomCommands.cpp
+++ b/src/CustomCommands.cpp
@@ -83,7 +83,67 @@ static void helpCommand(std::string full, std::vector<std::string>& args, CNSock
 }
 
 static void accessCommand(std::string full, std::vector<std::string>& args, CNSocket* sock) {
-    Chat::sendServerMessage(sock, "Your access level is " + std::to_string(PlayerManager::getPlayer(sock)->accountLevel));
+    if (args.size() < 2) {
+        Chat::sendServerMessage(sock, "Usage: /access <id> [new_level]");
+        Chat::sendServerMessage(sock, "Use . for id to select yourself");
+        return;
+    }
+
+    char *tmp;
+
+    Player* player;
+    if (args[1].compare(".") == 0) {
+        player = PlayerManager::getPlayer(sock);
+    } else {
+        int id = std::strtol(args[1].c_str(), &tmp, 10);
+        if (*tmp) {
+            Chat::sendServerMessage(sock, "Invalid player ID " + args[1]);
+            return;
+        }
+
+        player = PlayerManager::getPlayerFromID(id);
+        if (player == nullptr) {
+            Chat::sendServerMessage(sock, "Could not find player with ID " + std::to_string(id));
+            return;
+        }
+    }
+
+    std::string playerName = PlayerManager::getPlayerName(player);
+    int currentAccess = player->accountLevel;
+    if (args.size() < 3) {
+        // just check
+        Chat::sendServerMessage(sock, playerName + " has access level " + std::to_string(currentAccess));
+        return;
+    }
+
+    // Can't change the access level of someone with stronger privileges
+    // N.B. lower value = stronger privileges
+    Player* self = PlayerManager::getPlayer(sock);
+    int selfAccess = self->accountLevel;
+    if (currentAccess <= selfAccess) {
+        Chat::sendServerMessage(sock, "Can't change this player's access level (insufficient privileges)");
+        return;
+    }
+
+    int newAccess = std::strtol(args[2].c_str(), &tmp, 10);
+    if (*tmp) {
+        Chat::sendServerMessage(sock, "Invalid access level " + args[2]);
+        return;
+    }
+
+    // Can only assign an access level weaker than yours
+    if (newAccess <= selfAccess) {
+        Chat::sendServerMessage(sock, "Can't assign stronger privileges than your own");
+        return;
+    }
+
+    player->accountLevel = newAccess;
+
+    // Save to database
+    int accountId = Database::getAccountIdForPlayer(player->iID);
+    Database::updateAccountLevel(accountId, newAccess);
+
+    Chat::sendServerMessage(sock, "Changed access level for " + playerName + " from " + std::to_string(currentAccess) + " to " + std::to_string(newAccess));
 }
 
 static void populationCommand(std::string full, std::vector<std::string>& args, CNSocket* sock) {
@@ -1200,7 +1260,7 @@ static void registerCommand(std::string cmd, int requiredLevel, CommandHandler h
 
 void CustomCommands::init() {
     registerCommand("help", 100, helpCommand, "list all unlocked server-side commands");
-    registerCommand("access", 100, accessCommand, "print your access level");
+    registerCommand("access", 100, accessCommand, "check or change access levels");
     registerCommand("instance", 30, instanceCommand, "print or change your current instance");
     registerCommand("mss", 30, mssCommand, "edit Monkey Skyway routes");
     registerCommand("npcr", 30, npcRotateCommand, "rotate NPCs");

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -212,7 +212,12 @@ static void enterPlayer(CNSocket* sock, CNPacketData* data) {
 
     response.iID = plr->iID;
     response.uiSvrTime = getTime();
-    response.PCLoadData2CL.iUserLevel = plr->accountLevel;
+
+    // The only client-side use of the account level is to block
+    // the sending of GM packets. Since account level can be changed
+    // at runtime and we validate it serverside, we can leave this at 0.
+    response.PCLoadData2CL.iUserLevel = 0; // plr->accountLevel;
+
     response.PCLoadData2CL.iHP = plr->HP;
     response.PCLoadData2CL.iLevel = plr->level;
     response.PCLoadData2CL.iCandy = plr->money;

--- a/src/db/Database.hpp
+++ b/src/db/Database.hpp
@@ -46,8 +46,12 @@ namespace Database {
     void close();
 
     void findAccount(Account* account, std::string login);
-    // returns ID, 0 if something failed
+
+    // return ID, 0 if something failed
+    int getAccountIdForPlayer(int playerId);
     int addAccount(std::string login, std::string password);
+
+    void updateAccountLevel(int accountId, int accountLevel);
 
     // interface for the /ban command
     bool banPlayer(int playerId, std::string& reason);


### PR DESCRIPTION
Modifies the `/access` command to allow changing of account level at runtime (fixes #194).
```
Usage: /access <id> [new_level]
Use . for id to select yourself
```
The player can only modify the account level of someone with weaker privileges, and can only assign privileges weaker than their own. This change is persistent (immediately written to the database).
If no new level is provided, the command just prints the current access level of the player.

Using this command on other players is only permitted at access level 30.