### PR TITLE
Client synchronization improvements

### DIFF
--- a/src/Buddies.cpp
+++ b/src/Buddies.cpp
@@ -30,7 +30,7 @@ static bool playerHasBuddyWithID(Player* plr, int buddyID) {
 #pragma endregion
 
 // Refresh buddy list
-void Buddies::refreshBuddyList(CNSocket* sock) {
+void Buddies::sendBuddyList(CNSocket* sock) {
     Player* plr = PlayerManager::getPlayer(sock);
     int buddyCnt = Database::getNumBuddies(plr);
 
@@ -277,15 +277,6 @@ static void reqFindNameBuddyAccept(CNSocket* sock, CNPacketData* data) {
 // Getting buddy state
 static void reqPktGetBuddyState(CNSocket* sock, CNPacketData* data) {
     Player* plr = PlayerManager::getPlayer(sock);
-
-    /*
-     * If the buddy list wasn't synced a second time yet, sync it.
-     * Not sure why we have to do it again for the client not to trip up.
-     */
-    if (!plr->buddiesSynced) {
-        refreshBuddyList(sock);
-        plr->buddiesSynced = true;
-    }
     
     INITSTRUCT(sP_FE2CL_REP_GET_BUDDY_STATE_SUCC, resp);
     

--- a/src/Buddies.hpp
+++ b/src/Buddies.hpp
@@ -6,5 +6,5 @@ namespace Buddies {
     void init();
 
     // Buddy list
-    void refreshBuddyList(CNSocket* sock);
+    void sendBuddyList(CNSocket* sock);
 }

--- a/src/Combat.cpp
+++ b/src/Combat.cpp
@@ -908,6 +908,10 @@ static void playerTick(CNServer *serv, time_t currTime) {
         Player *plr = pair.second;
         bool transmit = false;
 
+        // don't tick players that haven't loaded in yet
+        if (!plr->initialLoadDone)
+            continue;
+
         // group ticks
         if (plr->group != nullptr)
             Groups::groupTickInfo(sock);

--- a/src/Combat.cpp
+++ b/src/Combat.cpp
@@ -908,10 +908,6 @@ static void playerTick(CNServer *serv, time_t currTime) {
         Player *plr = pair.second;
         bool transmit = false;
 
-        // don't tick players that haven't loaded in yet
-        if (!plr->initialLoadDone)
-            continue;
-
         // group ticks
         if (plr->group != nullptr)
             Groups::groupTickInfo(sock);

--- a/src/Player.hpp
+++ b/src/Player.hpp
@@ -72,8 +72,8 @@ struct Player : public Entity, public ICombatant {
     bool notify = false;
     bool hidden = false;
     bool unwarpable = false;
+    bool initialLoadDone = false;
 
-    bool buddiesSynced = false;
     int64_t buddyIDs[50] = {};
     bool isBuddyBlocked[50] = {};
 

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -299,10 +299,6 @@ static void enterPlayer(CNSocket* sock, CNPacketData* data) {
 
     sock->sendPacket(response, P_FE2CL_REP_PC_ENTER_SUCC);
 
-    // Academy builds receive nanos separately. Need to send this ASAP after P_FE2CL_REP_PC_ENTER_SUCC
-    // because the client will fail to render equipped nanos if it's sent too late
-    
-
     // transfer ownership of Player object into the shard (still valid in this function though)
     addPlayer(sock, plr);
 

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -293,11 +293,13 @@ static void enterPlayer(CNSocket* sock, CNPacketData* data) {
     sock->setActiveKey(SOCKETKEY_FE); // send all packets using the FE key from now on
 
     // Academy builds receive nanos in a separate packet. These need to be sent
-    // before P_FE2CL_REP_PC_ENTER_SUCC as well as after initial load
+    // before P_FE2CL_REP_PC_ENTER_SUCC as well as after
     // due to a race condition in the client :(
     sendNanoBookSubset(sock, plr);
 
     sock->sendPacket(response, P_FE2CL_REP_PC_ENTER_SUCC);
+
+    sendNanoBookSubset(sock, plr);
 
     // transfer ownership of Player object into the shard (still valid in this function though)
     addPlayer(sock, plr);
@@ -375,7 +377,6 @@ static void loadPlayer(CNSocket* sock, CNPacketData* data) {
         Missions::failInstancedMissions(sock); // auto-fail missions
         Buddies::sendBuddyList(sock); // buddy list
         Items::checkItemExpire(sock, plr); // vehicle expiration
-        sendNanoBookSubset(sock, plr); // nanos (post-load)
 
         plr->initialLoadDone = true;
     }

--- a/src/PlayerManager.cpp
+++ b/src/PlayerManager.cpp
@@ -299,9 +299,9 @@ static void enterPlayer(CNSocket* sock, CNPacketData* data) {
     sock->setFEKey(lm->FEKey);
     sock->setActiveKey(SOCKETKEY_FE); // send all packets using the FE key from now on
 
-    // Academy builds receive nanos in a separate packet. These need to be sent
-    // before P_FE2CL_REP_PC_ENTER_SUCC as well as after
-    // due to a race condition in the client :(
+    // Academy builds receive nanos in a separate packet. An initial one with the size of the
+    // nano book needs to be sent before PC_ENTER_SUCC so the client can resize its nano arrays,
+    // and then proper packets with the nanos included must be sent after, while the game is loading.
     sendNanoBook(sock, plr, true);
 
     sock->sendPacket(response, P_FE2CL_REP_PC_ENTER_SUCC);


### PR DESCRIPTION
Makes a few changes to packet ordering during player loading to increase reliability in the client.
- Moves a few things from `PC_ENTER` handler to `LOADING_COMPLETE` handler, fired only once. This way we don't risk packets getting missed.
  - MOTD
  - Auto-fail missions
  - Buddy list sync (fixes bug where buddy list sometimes doesn't populate on login)
- For Academy only, fix a packet ordering issue causing players with high latency to not see their equipped nanos in the nanocom (fixes #262)