### PR TITLE
Docker: disable sandbox to fix crashes and update Dockerfile/compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build
-FROM debian:stable-slim as build
+FROM debian:stable-slim AS build
 
 WORKDIR /usr/src/app
 
@@ -14,7 +14,7 @@ COPY vendor ./vendor
 COPY .git ./.git
 COPY Makefile CMakeLists.txt version.h.in ./
 
-RUN make -j8
+RUN make nosandbox -j$(nproc)
 
 # prod
 FROM debian:stable-slim
@@ -29,4 +29,8 @@ COPY sql ./sql
 
 CMD ["/bin/fusion"]
 
-LABEL Name=openfusion Version=0.0.2
+EXPOSE 23000/tcp
+EXPOSE 23001/tcp
+EXPOSE 8001/tcp
+
+LABEL Name=openfusion Version=1.6.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
-version: '3.4'
-
 services:
   openfusion:
-    image: openfusion
     build:
       context: .
       dockerfile: ./Dockerfile
+    image: openfusion/openfusion:latest
     volumes:
       - ./config.ini:/usr/src/app/config.ini
       - ./database.db:/usr/src/app/database.db


### PR DESCRIPTION
* Disable sandbox when running docker build
* Add EXPOSE hints to Dockerfile
* as -> AS in Dockerfile to resolve warning
* Point docker-compose.yml to our Docker Hub image (openfusion/openfusion)
* Remove version property in docker-compose.yml as it was deprecated
* Change Dockerfile version to match software version