### PR TITLE
Fix gumball buff leaking to the wrong nano on slot change

### DIFF
--- a/src/Nanos.cpp
+++ b/src/Nanos.cpp
@@ -215,6 +215,14 @@ static void nanoEquipHandler(CNSocket* sock, CNPacketData* data) {
     resp.iNanoID = nano->iNanoID;
     resp.iNanoSlotNum = nano->iNanoSlotNum;
 
+    /*
+     * A gumball (stimpak) buff is keyed to the nano slot, not the nano itself.
+     * If this slot's occupant is changing, drop the buff so the incoming nano
+     * doesn't inherit the boost (which would also bypass the gumball type check).
+     */
+    if (plr->equippedNanos[nano->iNanoSlotNum] != nano->iNanoID)
+        plr->removeBuff(ECSB_STIMPAKSLOT1 + nano->iNanoSlotNum);
+
     // Update player
     plr->equippedNanos[nano->iNanoSlotNum] = nano->iNanoID;
 
@@ -239,6 +247,9 @@ static void nanoUnEquipHandler(CNSocket* sock, CNPacketData* data) {
     // unsummon nano if removed
     if (plr->equippedNanos[nano->iNanoSlotNum] == plr->activeNano)
         summonNano(sock, -1);
+
+    // a gumball (stimpak) buff is tied to this slot; drop it as the nano leaves
+    plr->removeBuff(ECSB_STIMPAKSLOT1 + nano->iNanoSlotNum);
 
     // update player
     plr->equippedNanos[nano->iNanoSlotNum] = 0;


### PR DESCRIPTION
# Fix gumball buff leaking to the wrong nano on slot change

## Problem

The gumball (stimpak) buff is keyed to the nano **slot** (`ECSB_STIMPAKSLOT1 + slot`), not to the nano that consumed the gumball. Nothing cleared that buff when the slot's occupant changed, so swapping equipped nanos (or replacing one in place) left the buff on the slot and the incoming nano inherited the boost.

This bypasses the gumball/nano-style match check in `useGumball()` (a gumball can be applied to a nano whose style it doesn't match) and shows the buff icon on the wrong nano in the client HUD.

## Fix

Drop the slot's stimpak buff whenever its occupant changes:

- **`nanoEquipHandler`** — when a *different* nano is equipped into the slot. A slot swap carries no source-slot field and no dedicated opcode, so the client expresses it as in-place `NANO_EQUIP` overwrites; this is the path that catches the reported exploit.
- **`nanoUnEquipHandler`** — when the nano leaves the slot.

`removeBuff()` clears the effect and resends the corrected condition bitflag, so both the gameplay boost and the HUD icon are fixed.

## Testing (protocol 104)

Reproduced on an unpatched build and confirmed fixed on the patched build, covering:

- Equipping a new nano onto a buffed slot.
- Unequip + re-equip.

Normal gumball use on the matching nano is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
