### PR TITLE
Swampfire nano mission bug workaround | refactoring Missions.cpp

### DIFF
--- a/src/Missions.cpp
+++ b/src/Missions.cpp
@@ -595,30 +595,33 @@ void Missions::mobKilled(CNSocket *sock, int mobid, std::map<int, int>& rolls) {
             }
 
             // drop quest item
-            if (task["m_iCSUItemNumNeeded"][j] != 0 && !isQuestItemFull(sock, task["m_iCSUItemID"][j], task["m_iCSUItemNumNeeded"][j]) ) {
-                bool drop = rolls[plr->tasks[i]] % 100 < task["m_iSTItemDropRate"][j];
-                if (drop) {
-                    dropQuestItem(sock, plr->tasks[i], 1, task["m_iCSUItemID"][j], mobid);
-
-                    /*
-                     * Workaround: The client has a bug where it only sends a TASK_END request
-                     * for the first task of multiple that met their quest item requirements
-                     * at the same time. We deal with this by sending TASK_END response packets
-                     * proactively and then silently ignoring the extra TASK_END requests it
-                     * sends afterwards.
-                     */
-                    if (isQuestItemFull(sock, task["m_iCSUItemID"][j], task["m_iCSUItemNumNeeded"][j])) {
-                        INITSTRUCT(sP_FE2CL_REP_PC_TASK_END_SUCC, end);
-                        end.iTaskNum = plr->tasks[i];
-
-                        if (!endTask(sock, plr->tasks[i]))
-                            continue;
-
-                        sock->sendPacket(end, P_FE2CL_REP_PC_TASK_END_SUCC);
+            if (task["m_iCSUItemNumNeeded"][j] != 0) {
+                if (!isQuestItemFull(sock, task["m_iCSUItemID"][j], task["m_iCSUItemNumNeeded"][j])) {
+                    bool drop = rolls[plr->tasks[i]] % 100 < task["m_iSTItemDropRate"][j];
+                    if (drop) {
+                        dropQuestItem(sock, plr->tasks[i], 1, task["m_iCSUItemID"][j], mobid);
                     }
-                } else {
-                    // fail to drop (itemID == 0)
-                    dropQuestItem(sock, plr->tasks[i], 1, 0, mobid);
+                    else {
+                        // fail to drop (itemID == 0)
+                        dropQuestItem(sock, plr->tasks[i], 1, 0, mobid);
+                    }
+                }
+                
+                /*
+                * Workaround: The client has a bug where it only sends a TASK_END request
+                * for the first task of multiple that met their quest item requirements
+                * at the same time. We deal with this by sending TASK_END response packets
+                * proactively and then silently ignoring the extra TASK_END requests it
+                * sends afterwards.
+                */
+                if (isQuestItemFull(sock, task["m_iCSUItemID"][j], task["m_iCSUItemNumNeeded"][j])) {
+                    INITSTRUCT(sP_FE2CL_REP_PC_TASK_END_SUCC, end);
+                    end.iTaskNum = plr->tasks[i];
+
+                    if (!endTask(sock, plr->tasks[i]))
+                        continue;
+
+                    sock->sendPacket(end, P_FE2CL_REP_PC_TASK_END_SUCC);
                 }
             }
         }


### PR DESCRIPTION
## Summary

The current logic in Missions.cpp only checks whether all necessary quest items for a task have been gathered once an item is dropped. If the logic somehow fails (which seems to happen to many people during the swampfire nano mission as per the FAQ; maybe the packet fails to deliver?), then the player will be stuck since the quest items will be full and the logic which ends the task will not be accessible by the code anymore. Then, they won't be able to progress in the game until a dev helps them.

This fix takes out the logic which checks if all the items have been gathered outside of the code section that is only accessible once an item is dropped. Then, if the issue is encountered, the player can just kill one or more npcs of the type they need to kill for the item and the quest task will be completed. 

## Testing
I reproduced the bug on my own server and fixed it by applying the changes in this pull request. I have played now for 3 more levels and have completed many missions and I have not encountered any issues with the new logic.

## Future
This is is merely a workaround for the bug, since it ensures that players are not stuck if the bug happens, but it is still unknown why sometimes getting all necessary items for the quest fails to complete the task.
